### PR TITLE
feat: approximate betweenness centrality

### DIFF
--- a/lib/dux/graph.ex
+++ b/lib/dux/graph.ex
@@ -1086,6 +1086,285 @@ defmodule Dux.Graph do
   end
 
   # ---------------------------------------------------------------------------
+  # Betweenness centrality
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Compute approximate betweenness centrality via Brandes' algorithm.
+
+  Betweenness centrality measures how often a vertex lies on shortest paths
+  between other vertices. High-BC vertices are "bridges" in the network.
+
+  Uses a sample of source vertices for efficiency. The result is normalized
+  by `2 / ((n-1)(n-2))` for undirected graphs so values fall in [0, 1].
+
+  Returns a `%Dux{}` with columns `[vertex_id, bc]`.
+
+  ## Options
+
+    * `:sample` — number of source vertices to sample (default: `min(n, 100)`)
+    * `:seed` — random seed for reproducible sampling (default: random)
+    * `:normalize` — whether to normalize scores (default: `true`)
+
+  ## Examples
+
+      vertices = Dux.from_list([%{"id" => 1}, %{"id" => 2}, %{"id" => 3}])
+      edges = Dux.from_list([
+        %{"src" => 1, "dst" => 2}, %{"src" => 2, "dst" => 1},
+        %{"src" => 2, "dst" => 3}, %{"src" => 3, "dst" => 2}
+      ])
+      graph = Dux.Graph.new(vertices: vertices, edges: edges)
+      Dux.Graph.betweenness_centrality(graph) |> Dux.sort_by(desc: :bc) |> Dux.to_rows()
+  """
+  def betweenness_centrality(%__MODULE__{} = graph, opts \\ []) do
+    workers = graph.workers
+
+    meta = %{
+      algorithm: :betweenness_centrality,
+      n_vertices: vertex_count(graph),
+      n_edges: edge_count(graph),
+      distributed: workers != nil
+    }
+
+    :telemetry.span([:dux, :graph, :algorithm], meta, fn ->
+      result =
+        if workers do
+          bc_distributed(graph, opts, workers)
+        else
+          bc_local(graph, opts)
+        end
+
+      {result, meta}
+    end)
+  end
+
+  defp bc_local(graph, opts) do
+    conn = Dux.Connection.get_conn()
+    vid = graph.vertex_id
+    src = graph.edge_src
+    dst = graph.edge_dst
+    normalize = Keyword.get(opts, :normalize, true)
+
+    # Get all vertex IDs
+    vertex_ids = get_vertex_ids(graph, conn, vid)
+    n = length(vertex_ids)
+
+    # Sample source vertices
+    sample_size = Keyword.get(opts, :sample, min(n, 100))
+    seed = Keyword.get(opts, :seed)
+
+    sources =
+      if seed do
+        :rand.seed(:exsss, {seed, seed, seed})
+        Enum.take_random(vertex_ids, sample_size)
+      else
+        Enum.take_random(vertex_ids, sample_size)
+      end
+
+    # Build bidirectional adjacency list once
+    adj = build_adjacency(graph, conn, src, dst)
+
+    # Run Brandes from each source, accumulate BC scores
+    bc_scores =
+      Enum.reduce(sources, %{}, fn source, acc ->
+        brandes_from_source(conn, source, adj, acc)
+      end)
+
+    # Normalize: BC(v) = bc_scores(v) * (n / sample_size) * normalization_factor
+    # For undirected: normalize by 2/((n-1)(n-2))
+    scale = n / max(sample_size, 1)
+
+    norm_factor =
+      if normalize and n > 2 do
+        scale * 2.0 / ((n - 1) * (n - 2))
+      else
+        scale
+      end
+
+    rows =
+      Enum.map(vertex_ids, fn v ->
+        %{String.to_atom(vid) => v, bc: Map.get(bc_scores, v, 0.0) * norm_factor}
+      end)
+
+    Dux.from_list(rows)
+  end
+
+  defp get_vertex_ids(graph, conn, vid) do
+    {v_sql, _} = Dux.QueryBuilder.build(graph.vertices, conn)
+    ref = Dux.Backend.query(conn, "SELECT #{qi(vid)} FROM (#{v_sql}) __v ORDER BY #{qi(vid)}")
+    cols = Dux.Backend.table_to_columns(conn, ref)
+    cols[vid] || []
+  end
+
+  defp build_adjacency(graph, conn, src_col, dst_col) do
+    {edges_sql, _} = Dux.QueryBuilder.build(graph.edges, conn)
+    edges_ref = Dux.Backend.query(conn, edges_sql)
+    edge_cols = Dux.Backend.table_to_columns(conn, edges_ref)
+    srcs = edge_cols[src_col] || []
+    dsts = edge_cols[dst_col] || []
+
+    (Enum.zip(srcs, dsts) ++ Enum.zip(dsts, srcs))
+    |> Enum.reduce(%{}, fn {s, d}, a ->
+      Map.update(a, s, MapSet.new([d]), &MapSet.put(&1, d))
+    end)
+    |> Map.new(fn {k, v} -> {k, MapSet.to_list(v)} end)
+  end
+
+  # Brandes' algorithm from a single source vertex, entirely in Elixir.
+  # Phase 1: BFS level-by-level to get (node, dist, sigma).
+  # Phase 2: Back-propagation to accumulate dependency scores.
+  #
+  # We avoid recursive CTEs here because UNION ALL BFS explodes
+  # exponentially, and USING KEY doesn't accumulate sigma.
+  # Instead we load the adjacency list once and do BFS in Elixir.
+  defp brandes_from_source(_conn, source, adj, acc) do
+    initial = %{source => {0, 1}}
+    {node_data, max_dist} = bfs_levels(adj, [source], initial, 0)
+
+    if max_dist == 0, do: acc, else: accumulate_bc(source, node_data, adj, max_dist, acc)
+  end
+
+  defp accumulate_bc(source, node_data, adj, max_dist, acc) do
+    delta = bc_backpropagate(node_data, adj, max_dist)
+
+    Enum.reduce(delta, acc, fn {v, d}, a ->
+      if v == source, do: a, else: Map.update(a, v, d, &(&1 + d))
+    end)
+  end
+
+  # Back-propagation phase of Brandes: process levels in reverse order.
+  defp bc_backpropagate(node_data, adj, max_dist) do
+    Enum.reduce(max_dist..1//-1, %{}, fn d, delta ->
+      nodes_at_d = for {n, {dd, _}} <- node_data, dd == d, do: n
+
+      Enum.reduce(nodes_at_d, delta, fn w, delta ->
+        bc_propagate_from(w, d, node_data, adj, delta)
+      end)
+    end)
+  end
+
+  defp bc_propagate_from(w, d, node_data, adj, delta) do
+    {_dw, sigma_w} = Map.fetch!(node_data, w)
+    delta_w = Map.get(delta, w, 0.0)
+
+    predecessors =
+      Map.get(adj, w, [])
+      |> Enum.filter(&(elem(Map.get(node_data, &1, {nil, nil}), 0) == d - 1))
+
+    Enum.reduce(predecessors, delta, fn v, delta ->
+      {_dv, sigma_v} = Map.fetch!(node_data, v)
+      contribution = sigma_v / sigma_w * (1 + delta_w)
+      Map.update(delta, v, contribution, &(&1 + contribution))
+    end)
+  end
+
+  # BFS level-by-level. Returns {node_data, max_dist} where
+  # node_data is %{node => {dist, sigma}}.
+  defp bfs_levels(_adj, [], visited, dist), do: {visited, dist}
+
+  defp bfs_levels(adj, frontier, visited, dist) do
+    next_dist = dist + 1
+
+    {next_frontier_map, visited} =
+      Enum.reduce(frontier, {%{}, visited}, fn node, {nf, vis} ->
+        {_d, sigma} = Map.fetch!(vis, node)
+        expand_neighbors(Map.get(adj, node, []), sigma, next_dist, nf, vis)
+      end)
+
+    # Commit frontier to visited
+    visited =
+      Enum.reduce(next_frontier_map, visited, fn {node, sigma}, vis ->
+        case Map.get(vis, node) do
+          {^next_dist, existing} -> Map.put(vis, node, {next_dist, existing + sigma})
+          nil -> Map.put(vis, node, {next_dist, sigma})
+          _ -> vis
+        end
+      end)
+
+    next_frontier = Map.keys(next_frontier_map)
+
+    if next_frontier == [] do
+      {visited, dist}
+    else
+      bfs_levels(adj, next_frontier, visited, next_dist)
+    end
+  end
+
+  defp expand_neighbors(neighbors, sigma, next_dist, nf, vis) do
+    Enum.reduce(neighbors, {nf, vis}, fn neighbor, {nf, vis} ->
+      case Map.get(vis, neighbor) do
+        nil ->
+          {Map.update(nf, neighbor, sigma, &(&1 + sigma)), vis}
+
+        {^next_dist, _} ->
+          {Map.update(nf, neighbor, sigma, &(&1 + sigma)), vis}
+
+        {existing_dist, _} when existing_dist < next_dist ->
+          {nf, vis}
+
+        _ ->
+          {nf, vis}
+      end
+    end)
+  end
+
+  # Distributed: partition source vertices across workers.
+  # BFS + back-propagation is pure Elixir, so we build adjacency once
+  # on the coordinator and partition the source vertices across tasks.
+  # The adjacency is shared (read-only) — no need to send to workers.
+  defp bc_distributed(graph, opts, _workers) do
+    conn = Dux.Connection.get_conn()
+    vid = graph.vertex_id
+    src = graph.edge_src
+    dst = graph.edge_dst
+    normalize = Keyword.get(opts, :normalize, true)
+
+    vertex_ids = get_vertex_ids(graph, conn, vid)
+    n = length(vertex_ids)
+
+    sample_size = Keyword.get(opts, :sample, min(n, 100))
+    seed = Keyword.get(opts, :seed)
+
+    sources =
+      if seed do
+        :rand.seed(:exsss, {seed, seed, seed})
+        Enum.take_random(vertex_ids, sample_size)
+      else
+        Enum.take_random(vertex_ids, sample_size)
+      end
+
+    adj = build_adjacency(graph, conn, src, dst)
+
+    # Parallel Brandes across source vertices using Task.async_stream
+    bc_scores =
+      sources
+      |> Task.async_stream(
+        fn source -> brandes_from_source(conn, source, adj, %{}) end,
+        max_concurrency: System.schedulers_online(),
+        timeout: 60_000
+      )
+      |> Enum.reduce(%{}, fn {:ok, partial}, acc ->
+        Map.merge(acc, partial, fn _k, v1, v2 -> v1 + v2 end)
+      end)
+
+    scale = n / max(sample_size, 1)
+
+    norm_factor =
+      if normalize and n > 2 do
+        scale * 2.0 / ((n - 1) * (n - 2))
+      else
+        scale
+      end
+
+    rows =
+      Enum.map(vertex_ids, fn v ->
+        %{String.to_atom(vid) => v, bc: Map.get(bc_scores, v, 0.0) * norm_factor}
+      end)
+
+    Dux.from_list(rows)
+  end
+
+  # ---------------------------------------------------------------------------
   # Counts
   # ---------------------------------------------------------------------------
 

--- a/test/dux/betweenness_centrality_test.exs
+++ b/test/dux/betweenness_centrality_test.exs
@@ -1,0 +1,348 @@
+defmodule Dux.BetweennessCentralityTest do
+  use ExUnit.Case, async: false
+
+  alias Dux.Remote.Worker
+
+  # ---------------------------------------------------------------------------
+  # Happy path
+  # ---------------------------------------------------------------------------
+
+  describe "local betweenness centrality" do
+    test "line graph: middle vertex has highest BC" do
+      # 1 -- 2 -- 3 -- 4 -- 5
+      # Vertex 3 should have highest BC (all paths between sides pass through it)
+      vertices = Dux.from_list(Enum.map(1..5, &%{id: &1}))
+
+      edges =
+        Dux.from_list([
+          %{src: 1, dst: 2},
+          %{src: 2, dst: 1},
+          %{src: 2, dst: 3},
+          %{src: 3, dst: 2},
+          %{src: 3, dst: 4},
+          %{src: 4, dst: 3},
+          %{src: 4, dst: 5},
+          %{src: 5, dst: 4}
+        ])
+
+      graph = Dux.Graph.new(vertices: vertices, edges: edges)
+
+      result =
+        Dux.Graph.betweenness_centrality(graph, sample: 5, seed: 42)
+        |> Dux.sort_by(desc: :bc)
+        |> Dux.to_rows()
+
+      # Vertex 3 should be first (highest BC)
+      assert hd(result)["id"] == 3
+
+      # Vertex 3 BC > vertex 2 BC > vertex 1 BC
+      bc_map = Map.new(result, fn r -> {r["id"], r["bc"]} end)
+      assert bc_map[3] > bc_map[2]
+      assert bc_map[2] > bc_map[1]
+
+      # Endpoints should have zero BC (no shortest paths pass through them)
+      assert bc_map[1] == 0.0
+      assert bc_map[5] == 0.0
+    end
+
+    test "star graph: center has highest BC" do
+      # Center: 1, spokes: 2,3,4,5
+      vertices = Dux.from_list(Enum.map(1..5, &%{id: &1}))
+
+      edges =
+        Dux.from_list(
+          for spoke <- 2..5, dir <- [:fwd, :bwd] do
+            case dir do
+              :fwd -> %{src: 1, dst: spoke}
+              :bwd -> %{src: spoke, dst: 1}
+            end
+          end
+        )
+
+      graph = Dux.Graph.new(vertices: vertices, edges: edges)
+
+      result =
+        Dux.Graph.betweenness_centrality(graph, sample: 5, seed: 42)
+        |> Dux.sort_by(desc: :bc)
+        |> Dux.to_rows()
+
+      # Center vertex 1 has highest BC
+      assert hd(result)["id"] == 1
+
+      # All spokes have zero BC
+      bc_map = Map.new(result, fn r -> {r["id"], r["bc"]} end)
+
+      for spoke <- 2..5 do
+        assert bc_map[spoke] == 0.0
+      end
+    end
+
+    test "complete graph: all vertices have equal BC" do
+      # K4: all connected to all — BC is equal for all vertices
+      vertices = Dux.from_list(Enum.map(1..4, &%{id: &1}))
+
+      edges =
+        Dux.from_list(
+          for i <- 1..4, j <- 1..4, i != j do
+            %{src: i, dst: j}
+          end
+        )
+
+      graph = Dux.Graph.new(vertices: vertices, edges: edges)
+
+      result =
+        Dux.Graph.betweenness_centrality(graph, sample: 4, seed: 42)
+        |> Dux.to_rows()
+
+      bcs = Enum.map(result, & &1["bc"])
+      # All should be equal (within tolerance)
+      assert_in_delta Enum.min(bcs), Enum.max(bcs), 0.01
+    end
+
+    test "triangle: all vertices have equal BC" do
+      vertices = Dux.from_list([%{id: 1}, %{id: 2}, %{id: 3}])
+
+      edges =
+        Dux.from_list([
+          %{src: 1, dst: 2},
+          %{src: 2, dst: 1},
+          %{src: 2, dst: 3},
+          %{src: 3, dst: 2},
+          %{src: 1, dst: 3},
+          %{src: 3, dst: 1}
+        ])
+
+      graph = Dux.Graph.new(vertices: vertices, edges: edges)
+
+      result =
+        Dux.Graph.betweenness_centrality(graph, sample: 3, seed: 42)
+        |> Dux.to_rows()
+
+      bcs = Enum.map(result, & &1["bc"])
+      assert_in_delta Enum.min(bcs), Enum.max(bcs), 0.01
+    end
+
+    test "seed produces reproducible results" do
+      vertices = Dux.from_list(Enum.map(1..10, &%{id: &1}))
+
+      edges =
+        Dux.from_list(
+          for i <- 1..9 do
+            [%{src: i, dst: i + 1}, %{src: i + 1, dst: i}]
+          end
+          |> List.flatten()
+        )
+
+      graph = Dux.Graph.new(vertices: vertices, edges: edges)
+
+      r1 =
+        Dux.Graph.betweenness_centrality(graph, sample: 5, seed: 123)
+        |> Dux.sort_by(:id)
+        |> Dux.to_rows()
+
+      r2 =
+        Dux.Graph.betweenness_centrality(graph, sample: 5, seed: 123)
+        |> Dux.sort_by(:id)
+        |> Dux.to_rows()
+
+      for {row1, row2} <- Enum.zip(r1, r2) do
+        assert_in_delta row1["bc"], row2["bc"], 1.0e-10
+      end
+    end
+
+    test "normalize: false returns raw scores" do
+      vertices = Dux.from_list(Enum.map(1..5, &%{id: &1}))
+
+      edges =
+        Dux.from_list([
+          %{src: 1, dst: 2},
+          %{src: 2, dst: 1},
+          %{src: 2, dst: 3},
+          %{src: 3, dst: 2},
+          %{src: 3, dst: 4},
+          %{src: 4, dst: 3},
+          %{src: 4, dst: 5},
+          %{src: 5, dst: 4}
+        ])
+
+      graph = Dux.Graph.new(vertices: vertices, edges: edges)
+
+      normalized =
+        Dux.Graph.betweenness_centrality(graph, sample: 5, seed: 42, normalize: true)
+        |> Dux.to_rows()
+
+      raw =
+        Dux.Graph.betweenness_centrality(graph, sample: 5, seed: 42, normalize: false)
+        |> Dux.to_rows()
+
+      # Normalized values should be smaller than raw
+      max_norm = normalized |> Enum.map(& &1["bc"]) |> Enum.max()
+      max_raw = raw |> Enum.map(& &1["bc"]) |> Enum.max()
+      assert max_raw >= max_norm
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Sad path
+  # ---------------------------------------------------------------------------
+
+  describe "edge cases" do
+    test "single vertex graph" do
+      vertices = Dux.from_list([%{id: 1}])
+      edges = Dux.from_list([%{src: 1, dst: 1}])
+      graph = Dux.Graph.new(vertices: vertices, edges: edges)
+
+      result =
+        Dux.Graph.betweenness_centrality(graph, sample: 1, seed: 42)
+        |> Dux.to_rows()
+
+      assert length(result) == 1
+      assert hd(result)["bc"] == 0.0
+    end
+
+    test "two vertices" do
+      vertices = Dux.from_list([%{id: 1}, %{id: 2}])
+
+      edges =
+        Dux.from_list([%{src: 1, dst: 2}, %{src: 2, dst: 1}])
+
+      graph = Dux.Graph.new(vertices: vertices, edges: edges)
+
+      result =
+        Dux.Graph.betweenness_centrality(graph, sample: 2, seed: 42)
+        |> Dux.to_rows()
+
+      # With only 2 vertices, no vertex can be "between" others
+      bcs = Enum.map(result, & &1["bc"])
+      assert Enum.all?(bcs, &(&1 == 0.0))
+    end
+
+    test "disconnected graph" do
+      # Two disconnected components: {1,2} and {3,4}
+      vertices = Dux.from_list(Enum.map(1..4, &%{id: &1}))
+
+      edges =
+        Dux.from_list([
+          %{src: 1, dst: 2},
+          %{src: 2, dst: 1},
+          %{src: 3, dst: 4},
+          %{src: 4, dst: 3}
+        ])
+
+      graph = Dux.Graph.new(vertices: vertices, edges: edges)
+
+      result =
+        Dux.Graph.betweenness_centrality(graph, sample: 4, seed: 42)
+        |> Dux.to_rows()
+
+      # All should have 0 BC (no bridges possible in disconnected pairs)
+      bcs = Enum.map(result, & &1["bc"])
+      assert Enum.all?(bcs, &(&1 == 0.0))
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Karate club dataset
+  # ---------------------------------------------------------------------------
+
+  describe "karate club" do
+    test "known high-BC vertices in Zachary's karate club" do
+      graph = Dux.Datasets.karate_club()
+
+      result =
+        Dux.Graph.betweenness_centrality(graph, sample: 34, seed: 42)
+        |> Dux.sort_by(desc: :bc)
+        |> Dux.to_rows()
+
+      top_5_ids = Enum.take(result, 5) |> Enum.map(& &1["id"]) |> MapSet.new()
+
+      # Vertices 1 and 34 are the two faction leaders — they should be in top 5
+      assert MapSet.member?(top_5_ids, 1)
+      assert MapSet.member?(top_5_ids, 34)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Distributed
+  # ---------------------------------------------------------------------------
+
+  describe "distributed betweenness centrality" do
+    test "distributed matches local for small graph" do
+      {:ok, w1} = Worker.start_link()
+      {:ok, w2} = Worker.start_link()
+
+      on_exit(fn ->
+        Enum.each([w1, w2], fn w ->
+          try do
+            GenServer.stop(w)
+          catch
+            :exit, _ -> :ok
+          end
+        end)
+      end)
+
+      vertices = Dux.from_list(Enum.map(1..6, &%{id: &1}))
+
+      edges =
+        Dux.from_list([
+          %{src: 1, dst: 2},
+          %{src: 2, dst: 1},
+          %{src: 2, dst: 3},
+          %{src: 3, dst: 2},
+          %{src: 3, dst: 4},
+          %{src: 4, dst: 3},
+          %{src: 4, dst: 5},
+          %{src: 5, dst: 4},
+          %{src: 5, dst: 6},
+          %{src: 6, dst: 5}
+        ])
+
+      local_graph = Dux.Graph.new(vertices: vertices, edges: edges)
+
+      dist_graph =
+        Dux.Graph.new(vertices: vertices, edges: edges)
+        |> Dux.Graph.distribute([w1, w2])
+
+      local_result =
+        Dux.Graph.betweenness_centrality(local_graph, sample: 6, seed: 42)
+        |> Dux.sort_by(:id)
+        |> Dux.to_rows()
+
+      dist_result =
+        Dux.Graph.betweenness_centrality(dist_graph, sample: 6, seed: 42)
+        |> Dux.sort_by(:id)
+        |> Dux.to_rows()
+
+      for {local, dist} <- Enum.zip(local_result, dist_result) do
+        assert local["id"] == dist["id"]
+        assert_in_delta local["bc"], dist["bc"], 0.01
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Adversarial
+  # ---------------------------------------------------------------------------
+
+  describe "adversarial" do
+    test "sample larger than vertex count doesn't crash" do
+      vertices = Dux.from_list([%{id: 1}, %{id: 2}, %{id: 3}])
+
+      edges =
+        Dux.from_list([
+          %{src: 1, dst: 2},
+          %{src: 2, dst: 1},
+          %{src: 2, dst: 3},
+          %{src: 3, dst: 2}
+        ])
+
+      graph = Dux.Graph.new(vertices: vertices, edges: edges)
+
+      result =
+        Dux.Graph.betweenness_centrality(graph, sample: 1000, seed: 42)
+        |> Dux.to_rows()
+
+      assert length(result) == 3
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **`Dux.Graph.betweenness_centrality/2`** — Brandes' algorithm for approximate betweenness centrality
- Uses Elixir-side BFS + back-propagation with pure adjacency lists (avoids DuckDB recursive CTE explosion that caused OOM with UNION ALL)
- Options: `:sample` (default min(n, 100)), `:seed` (reproducible), `:normalize` (default true)
- Distributed path parallelizes source vertices across `Task.async_stream` with `System.schedulers_online()` concurrency
- Normalization: `2 / ((n-1)(n-2))` for undirected graphs, scaled by `n / sample_size`

## Test plan

- [x] Line graph: middle vertex has highest BC, endpoints have zero
- [x] Star graph: center has highest BC, spokes have zero
- [x] Complete graph / triangle: all vertices have equal BC
- [x] Seed produces reproducible results
- [x] Normalize vs raw scores
- [x] Edge cases: single vertex, two vertices, disconnected graph
- [x] Karate club dataset: vertices 1 and 34 (faction leaders) in top 5
- [x] Distributed matches local for small graph
- [x] Adversarial: sample > vertex count
- [x] 538 total tests, 0 failures, 0 credo issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)