### PR TITLE
feat: update ADBC + zero-copy IPC ingest and Nx tensor path

### DIFF
--- a/lib/dux.ex
+++ b/lib/dux.ex
@@ -1306,33 +1306,118 @@ defmodule Dux do
       col_name = to_col_name(column)
       computed = compute(dux)
       {:table, ref} = computed.source
-      columns = Dux.Backend.table_to_columns(Dux.Connection.get_conn(), ref)
+      conn = Dux.Connection.get_conn()
+      raw_columns = Dux.Backend.table_to_raw_columns(conn, ref)
 
-      values = Map.fetch!(columns, col_name)
-      dtype = Map.get(computed.dtypes, col_name)
+      case Map.fetch(raw_columns, col_name) do
+        {:ok, %Adbc.Column{} = col} ->
+          column_to_tensor(col)
 
-      nx_type =
-        case dtype do
-          {:s, n} ->
-            String.to_atom("s#{n}")
+        :error ->
+          raise ArgumentError, "column #{inspect(col_name)} not found"
+      end
+    end
 
-          {:u, n} ->
-            String.to_atom("u#{n}")
+    @doc false
+    def column_to_tensor(%Adbc.Column{field: field}) when not is_struct(field, Adbc.Field) do
+      raise ArgumentError, "expected an Adbc.Column with a valid field"
+    end
 
-          {:f, n} ->
-            String.to_atom("f#{n}")
+    def column_to_tensor(%Adbc.Column{field: field, data: data})
+        when not is_struct(data, Adbc.BufferData) do
+      raise ArgumentError,
+            "column #{inspect(field.name)} has non-numeric type: #{inspect(field.type)}"
+    end
 
-          :boolean ->
-            :u8
+    def column_to_tensor(%Adbc.Column{field: field, data: %Adbc.BufferData{} = buf, size: size}) do
+      case nx_type_for(field.type) do
+        {:direct, nx_type} ->
+          # Zero-copy: Arrow buffer → Nx tensor directly
+          if has_nulls?(buf, size) do
+            raise ArgumentError,
+                  "column #{inspect(field.name)} contains nulls; filter them before converting to tensor"
+          end
 
-          {:decimal, _, _} ->
-            :f64
+          Nx.from_binary(buf.data, nx_type, backend: Nx.BinaryBackend)
+          |> Nx.reshape({size})
 
-          other ->
-            raise ArgumentError, "column #{col_name} has non-numeric type: #{inspect(other)}"
-        end
+        {:boolean, _nx_type} ->
+          if has_nulls?(buf, size) do
+            raise ArgumentError,
+                  "column #{inspect(field.name)} contains nulls; filter them before converting to tensor"
+          end
 
-      Nx.tensor(values, type: nx_type)
+          # Booleans are bit-packed — unpack to u8
+          values = Adbc.Column.to_list(%Adbc.Column{field: field, data: buf, size: size})
+
+          Nx.tensor(
+            Enum.map(values, fn
+              true -> 1
+              false -> 0
+            end),
+            type: :u8
+          )
+
+        {:decimal, _nx_type} ->
+          if has_nulls?(buf, size) do
+            raise ArgumentError,
+                  "column #{inspect(field.name)} contains nulls; filter them before converting to tensor"
+          end
+
+          # Decimals are 128-bit integers — convert via Adbc.Column.to_list
+          values = Adbc.Column.to_list(%Adbc.Column{field: field, data: buf, size: size})
+
+          Nx.tensor(
+            Enum.map(values, fn
+              %Decimal{} = d -> Decimal.to_float(d)
+              v when is_number(v) -> v
+            end),
+            type: :f64
+          )
+
+        :unsupported ->
+          raise ArgumentError,
+                "column #{inspect(field.name)} has non-numeric type: #{inspect(field.type)}"
+      end
+    end
+
+    defp nx_type_for(:s8), do: {:direct, :s8}
+    defp nx_type_for(:s16), do: {:direct, :s16}
+    defp nx_type_for(:s32), do: {:direct, :s32}
+    defp nx_type_for(:s64), do: {:direct, :s64}
+    defp nx_type_for(:u8), do: {:direct, :u8}
+    defp nx_type_for(:u16), do: {:direct, :u16}
+    defp nx_type_for(:u32), do: {:direct, :u32}
+    defp nx_type_for(:u64), do: {:direct, :u64}
+    defp nx_type_for(:f16), do: {:direct, :f16}
+    defp nx_type_for(:f32), do: {:direct, :f32}
+    defp nx_type_for(:f64), do: {:direct, :f64}
+    defp nx_type_for(:boolean), do: {:boolean, :u8}
+    defp nx_type_for({:decimal128, _, _}), do: {:decimal, :f64}
+    defp nx_type_for({:decimal256, _, _}), do: {:decimal, :f64}
+    defp nx_type_for(_), do: :unsupported
+
+    defp has_nulls?(%Adbc.BufferData{validity: validity}, size) do
+      # All-ones validity means no nulls. Check if all bits in range are set.
+      expected_bytes = div(size + 7, 8)
+      full_bytes = div(size, 8)
+      remainder = rem(size, 8)
+
+      full_valid = :binary.copy(<<255>>, full_bytes)
+
+      case {byte_size(validity) >= expected_bytes, remainder} do
+        {false, _} ->
+          false
+
+        {true, 0} ->
+          :binary.part(validity, 0, full_bytes) != full_valid
+
+        {true, r} ->
+          mask = Bitwise.bsl(1, r) - 1
+
+          :binary.part(validity, 0, full_bytes) != full_valid or
+            Bitwise.band(:binary.at(validity, full_bytes), mask) != mask
+      end
     end
   end
 

--- a/lib/dux/backend.ex
+++ b/lib/dux/backend.ex
@@ -54,34 +54,36 @@ defmodule Dux.Backend do
 
     materialized = Adbc.Result.materialize(result)
 
-    # ADBC returns empty data list for 0-row results. Can't ingest empty columns.
-    # Instead, create the temp table via SQL (CREATE ... AS SELECT ... WHERE false)
-    # to preserve the schema.
-    if materialized.data == [] do
-      create_table_from_sql(conn, sql)
-    else
-      # ADBC ingest doesn't quote column names, so columns with spaces/special
-      # chars fail. Fall back to CREATE TABLE AS for those cases.
-      has_special_names = has_special_column_names?(materialized.data)
+    case flatten_batches(materialized.data) do
+      [] ->
+        # ADBC returns empty data for 0-row results. Can't ingest empty columns.
+        # Create the temp table via SQL to preserve the schema.
+        create_table_from_sql(conn, sql)
 
-      if has_special_names do
+      :multi_batch ->
+        # Multiple record batches — fall back to SQL to avoid concatenation.
         create_table_with_data(conn, sql)
-      else
-        try do
-          ingest_result = Adbc.Connection.ingest!(conn, materialized.data)
 
-          %TableRef{
-            name: ingest_result.table,
-            gc_ref: ingest_result,
-            node: node()
-          }
-        rescue
-          ArgumentError ->
-            # ADBC ingest doesn't support all DuckDB types (e.g. timestamps
-            # from postgres_scanner). Fall back to CREATE TABLE AS SELECT.
-            create_table_with_data(conn, sql)
+      columns ->
+        # Single batch — ingest directly (avoids SQL round-trip).
+        if has_special_column_names?(columns) do
+          create_table_with_data(conn, sql)
+        else
+          try do
+            ingest_result = Adbc.Connection.ingest!(conn, columns)
+
+            %TableRef{
+              name: ingest_result.table,
+              gc_ref: ingest_result,
+              node: node()
+            }
+          rescue
+            ArgumentError ->
+              # ADBC ingest doesn't support all DuckDB types (e.g. timestamps
+              # from postgres_scanner). Fall back to CREATE TABLE AS SELECT.
+              create_table_with_data(conn, sql)
+          end
         end
-      end
     end
   end
 
@@ -165,6 +167,31 @@ defmodule Dux.Backend do
   end
 
   @doc false
+  def table_to_raw_columns(conn, %TableRef{} = ref) do
+    result = Adbc.Connection.query!(conn, "SELECT * FROM #{qi(ref.name)}")
+    materialized = Adbc.Result.materialize(result)
+
+    case flatten_batches(materialized.data) do
+      [] -> %{}
+      :multi_batch -> table_to_raw_columns_multi(materialized.data)
+      columns -> Map.new(columns, fn col -> {col.field.name, col} end)
+    end
+  end
+
+  # Multi-batch: concatenate column buffers across batches by materializing to lists
+  # and rebuilding. Rare path — only for very large results.
+  defp table_to_raw_columns_multi(batches) do
+    batches
+    |> Enum.zip_with(fn columns_at_pos ->
+      [first | _] = columns_at_pos
+      name = first.field.name
+      values = Enum.flat_map(columns_at_pos, &Adbc.Column.to_list/1)
+      {name, Adbc.Column.new(values, name: name)}
+    end)
+    |> Map.new()
+  end
+
+  @doc false
   def table_to_rows(conn, %TableRef{} = ref) do
     result = Adbc.Connection.query!(conn, "SELECT * FROM #{qi(ref.name)}")
     map = Adbc.Result.to_map(result)
@@ -197,7 +224,7 @@ defmodule Dux.Backend do
     result = Adbc.Connection.query!(conn, "SELECT * FROM #{qi(ref.name)}")
     materialized = Adbc.Result.materialize(result)
 
-    if materialized.data == [] do
+    if flatten_batches(materialized.data) == [] do
       # ADBC can't serialize zero-row results to IPC.
       # Add a dummy row, serialize, and mark with a header so table_from_ipc can strip it.
       build_empty_table_ipc(conn, ref.name)
@@ -235,10 +262,9 @@ defmodule Dux.Backend do
   end
 
   def table_from_ipc(conn, <<"DUX_EMPTY"::binary, ipc::binary>>) do
-    # Empty table with schema — ingest the dummy row then delete it
-    result = Adbc.Result.from_ipc_stream!(ipc)
-    materialized = Adbc.Result.materialize(result)
-    ingest_result = Adbc.Connection.ingest!(conn, materialized.data)
+    # Empty table with schema — ingest the dummy row via zero-copy stream, then delete it
+    stream = Adbc.StreamResult.from_ipc_stream!(ipc)
+    ingest_result = Adbc.Connection.ingest!(conn, stream)
     # Delete the dummy row
     Adbc.Connection.query!(conn, "DELETE FROM #{qi(ingest_result.table)} WHERE true")
 
@@ -250,25 +276,37 @@ defmodule Dux.Backend do
   end
 
   def table_from_ipc(conn, binary) when is_binary(binary) do
-    result = Adbc.Result.from_ipc_stream!(binary)
-    materialized = Adbc.Result.materialize(result)
+    # Zero-copy path: load IPC stream and ingest directly without materializing.
+    # Falls back to materialized path if ingest fails (e.g. special column names).
+    stream = Adbc.StreamResult.from_ipc_stream!(binary)
+    ingest_result = Adbc.Connection.ingest!(conn, stream)
 
-    cond do
-      materialized.data == [] ->
+    %TableRef{
+      name: ingest_result.table,
+      gc_ref: ingest_result,
+      node: node()
+    }
+  rescue
+    _ ->
+      # ADBC ingest doesn't quote column names in DDL, so special chars fail.
+      # Fall back to materialize + safe-rename ingest.
+      result = Adbc.Result.from_ipc_stream!(binary)
+      materialized = Adbc.Result.materialize(result)
+      columns = flatten_batches(materialized.data)
+
+      if columns in [[], :multi_batch] do
         name = "__dux_#{:erlang.unique_integer([:positive])}"
-        Adbc.Connection.query!(conn, "CREATE TEMPORARY TABLE #{qi(name)} AS SELECT 1 WHERE false")
+
+        Adbc.Connection.query!(
+          conn,
+          "CREATE TEMPORARY TABLE #{qi(name)} AS SELECT 1 WHERE false"
+        )
+
         %TableRef{name: name, gc_ref: nil, node: node()}
-
-      has_special_column_names?(materialized.data) ->
-        # Can't use ingest — DuckDB doesn't quote column names in DDL.
-        # Ingest to a temp name first, then copy with proper quoting.
-        ingest_result = ingest_safe(conn, materialized.data)
+      else
+        ingest_result = ingest_safe(conn, columns)
         %TableRef{name: ingest_result.table, gc_ref: ingest_result, node: node()}
-
-      true ->
-        ingest_result = Adbc.Connection.ingest!(conn, materialized.data)
-        %TableRef{name: ingest_result.table, gc_ref: ingest_result, node: node()}
-    end
+      end
   end
 
   @sql_reserved ~w(
@@ -283,19 +321,9 @@ defmodule Dux.Backend do
   @doc false
   def sql_reserved_words, do: @sql_reserved
 
-  defp has_special_column_names?(columns) do
-    Enum.any?(columns, fn col ->
-      name = col.field.name
-
-      name != String.replace(name, ~r/[^a-zA-Z0-9_]/, "") or
-        String.downcase(name) in @sql_reserved
-    end)
-  end
-
   # Ingest data that has special column names by renaming to safe names,
   # ingesting, then renaming back via CREATE TABLE AS SELECT.
   defp ingest_safe(conn, columns) do
-    # Rename columns to safe names for ingest
     safe_columns =
       columns
       |> Enum.with_index()
@@ -305,7 +333,6 @@ defmodule Dux.Backend do
 
     ingest_result = Adbc.Connection.ingest!(conn, safe_columns)
 
-    # Now create a new table with the original column names
     original_names = Enum.map(columns, & &1.field.name)
 
     select_cols =
@@ -320,14 +347,32 @@ defmodule Dux.Backend do
       "CREATE TEMPORARY TABLE #{qi(final_name)} AS SELECT #{select_cols} FROM #{qi(ingest_result.table)}"
     )
 
-    # Return an "IngestResult-like" with the final table name
-    # Note: gc_ref is the original ingest_result which keeps the source alive
     %Adbc.IngestResult{
       ref: ingest_result.ref,
       table: final_name,
       num_rows: ingest_result.num_rows
     }
   end
+
+  defp has_special_column_names?(columns) do
+    Enum.any?(columns, fn col ->
+      name = col.field.name
+
+      name != String.replace(name, ~r/[^a-zA-Z0-9_]/, "") or
+        String.downcase(name) in @sql_reserved
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Batch helpers
+  # ---------------------------------------------------------------------------
+
+  # ADBC results contain a list of record batches (each a list of columns).
+  # For single-batch results (common), return the batch directly.
+  # For empty or multi-batch results, return [] (callers handle this via SQL fallback).
+  defp flatten_batches([single_batch]) when is_list(single_batch), do: single_batch
+  defp flatten_batches([_ | _]), do: :multi_batch
+  defp flatten_batches([]), do: []
 
   # ---------------------------------------------------------------------------
   # Value normalization

--- a/lib/dux/nx.ex
+++ b/lib/dux/nx.ex
@@ -3,7 +3,8 @@ if Code.ensure_loaded?(Nx) do
     @moduledoc """
     Implements `Nx.LazyContainer` for `%Dux{}`.
 
-    Numeric columns become tensors on demand. Non-numeric columns are skipped.
+    Numeric columns become tensors on demand via zero-copy from Arrow buffers.
+    Non-numeric columns are skipped.
     The result is a map of `%{column_name => tensor}`.
     """
 
@@ -11,41 +12,42 @@ if Code.ensure_loaded?(Nx) do
       computed = Dux.compute(dux)
       {:table, table_ref} = computed.source
       conn = Dux.Connection.get_conn()
-      columns = Dux.Backend.table_to_columns(conn, table_ref)
-      dtypes = computed.dtypes
+      raw_columns = Dux.Backend.table_to_raw_columns(conn, table_ref)
 
       {pairs, acc} =
-        columns
+        raw_columns
         |> Enum.sort_by(fn {name, _} -> name end)
-        |> Enum.flat_map_reduce(acc, &traverse_column(&1, &2, dtypes, fun))
+        |> Enum.flat_map_reduce(acc, &traverse_column(&1, &2, fun))
 
       {Map.new(pairs), acc}
     end
 
-    defp traverse_column({name, values}, acc, dtypes, fun) do
-      case nx_type(Map.get(dtypes, name)) do
+    defp traverse_column({name, %Adbc.Column{size: size} = col}, acc, fun) do
+      case nx_type_for_adbc(col.field.type) do
         nil ->
           {[], acc}
 
         nx_type ->
-          template = Nx.template({length(values)}, nx_type)
-          {result, acc} = fun.(template, fn -> Nx.tensor(values, type: nx_type) end, acc)
+          template = Nx.template({size}, nx_type)
+          {result, acc} = fun.(template, fn -> Dux.column_to_tensor(col) end, acc)
           {[{name, result}], acc}
       end
     end
 
-    defp nx_type({:s, 8}), do: :s8
-    defp nx_type({:s, 16}), do: :s16
-    defp nx_type({:s, 32}), do: :s32
-    defp nx_type({:s, 64}), do: :s64
-    defp nx_type({:u, 8}), do: :u8
-    defp nx_type({:u, 16}), do: :u16
-    defp nx_type({:u, 32}), do: :u32
-    defp nx_type({:u, 64}), do: :u64
-    defp nx_type({:f, 32}), do: :f32
-    defp nx_type({:f, 64}), do: :f64
-    defp nx_type(:boolean), do: :u8
-    defp nx_type({:decimal, _, _}), do: :f64
-    defp nx_type(_), do: nil
+    defp nx_type_for_adbc(:s8), do: :s8
+    defp nx_type_for_adbc(:s16), do: :s16
+    defp nx_type_for_adbc(:s32), do: :s32
+    defp nx_type_for_adbc(:s64), do: :s64
+    defp nx_type_for_adbc(:u8), do: :u8
+    defp nx_type_for_adbc(:u16), do: :u16
+    defp nx_type_for_adbc(:u32), do: :u32
+    defp nx_type_for_adbc(:u64), do: :u64
+    defp nx_type_for_adbc(:f16), do: :f16
+    defp nx_type_for_adbc(:f32), do: :f32
+    defp nx_type_for_adbc(:f64), do: :f64
+    defp nx_type_for_adbc(:boolean), do: :u8
+    defp nx_type_for_adbc({:decimal128, _, _}), do: :f64
+    defp nx_type_for_adbc({:decimal256, _, _}), do: :f64
+    defp nx_type_for_adbc(_), do: nil
   end
 end

--- a/lib/dux/query_builder.ex
+++ b/lib/dux/query_builder.ex
@@ -483,26 +483,8 @@ defmodule Dux.QueryBuilder do
           Map.get(row, name) || Map.get(row, String.to_atom(name))
         end)
 
-      %Adbc.Column{
-        field: %Adbc.Field{name: name, type: infer_type(values), nullable: true, metadata: nil},
-        data: values
-      }
+      Adbc.Column.new(values, name: name)
     end)
-  end
-
-  defp infer_type([]), do: :string
-
-  defp infer_type(values) do
-    sample = Enum.find(values, &(&1 != nil))
-
-    case sample do
-      nil -> :string
-      v when is_integer(v) -> :s64
-      v when is_float(v) -> :f64
-      v when is_binary(v) -> :string
-      v when is_boolean(v) -> :boolean
-      _ -> :string
-    end
   end
 
   defp ingest_columns(conn, columns) do

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "adbc": {:git, "https://github.com/livebook-dev/adbc.git", "402dfa39af1413c2ebcd3fd3cc7b95e63ab7621a", []},
+  "adbc": {:git, "https://github.com/livebook-dev/adbc.git", "9df1ed629a1ebfb271117b323d967f3df4395512", []},
   "benchee": {:hex, :benchee, "1.5.0", "4d812c31d54b0ec0167e91278e7de3f596324a78a096fd3d0bea68bb0c513b10", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}, {:statistex, "~> 1.1", [hex: :statistex, repo: "hexpm", optional: false]}, {:table, "~> 0.1.0", [hex: :table, repo: "hexpm", optional: true]}], "hexpm", "5b075393aea81b8ae74eadd1c28b1d87e8a63696c649d8293db7c4df3eb67535"},
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
   "castore": {:hex, :castore, "1.0.18", "5e43ef0ec7d31195dfa5a65a86e6131db999d074179d2ba5a8de11fe14570f55", [:mix], [], "hexpm", "f393e4fe6317829b158fb74d86eb681f737d2fe326aa61ccf6293c4104957e34"},


### PR DESCRIPTION
## Summary

- **Update ADBC** from `402dfa3` to `9df1ed6` — buffer-based column encoding (13 upstream commits by José)
- **Zero-copy IPC ingest** for distributed queries — `StreamResult.from_ipc_stream!` → `ingest!` bypasses materialization entirely
- **Zero-copy Nx tensors** — `Nx.from_binary(buffer.data)` reads Arrow buffers directly, skipping Elixir list creation
- **Fix** broadcast join failure with special column names (pre-existing bug, `ingest_safe` fallback was missing from `table_from_ipc`)

### Breaking ADBC changes addressed

| Change | Fix |
|---|---|
| `Adbc.Field` `:nullable` removed | Switch to `Adbc.Column.new/2` in `query_builder.ex` |
| `Result.data` now batched `[[col, ...], ...]` | `flatten_batches/1` helper + `:multi_batch` fallback |
| Column data uses `Adbc.BufferData` with raw Arrow binaries | Updated all `backend.ex` paths |

### Benchmarks (before → after)

| Benchmark | Before | After | Speedup | Memory |
|---|---|---|---|---|
| `from_query(100K)` | 56 ips | **189 ips** | **3.4x** | 1.92 MB → 164 KB (12x less) |
| `from_query(1M)` | 3.8 ips | **22 ips** | **5.8x** | 9.22 MB → 1.48 MB (6x less) |
| `filter(100K)` | 108 ips | **204 ips** | **1.9x** | 1.14 MB → 94 KB (12x less) |
| `mutate(100K)` | 37 ips | **135 ips** | **3.6x** | 5.32 MB → 212 KB (26x less) |
| `sort(100K)` | 51 ips | **97 ips** | **1.9x** | 3.49 MB → 163 KB (22x less) |

## Test plan

- [x] `mix check` passes (format, compile --warnings-as-errors, test, credo --strict)
- [x] 564 tests, 0 failures
- [x] Benchmarks run before and after
- [x] Zero-copy Nx path manually verified (`Nx.from_binary` on Arrow buffers)
- [x] Special column name broadcast join test now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)