### PR TITLE
feat: insert_into verb + distributed DuckLake reads

### DIFF
--- a/lib/dux.ex
+++ b/lib/dux.ex
@@ -335,6 +335,67 @@ defmodule Dux do
     write_copy(dux, path, "JSON", opts)
   end
 
+  @doc group: :io
+  @doc """
+  Insert a Dux pipeline's results into a table. Triggers computation.
+
+  The target can be any table DuckDB can write to — a local table, or a
+  table in an attached database (Postgres, DuckLake, etc.). The pipeline
+  is compiled to SQL and executed as `INSERT INTO target SELECT ...`.
+
+  ## Options
+
+    * `:create` — create the target table if it doesn't exist (default: `false`).
+      Uses `CREATE TABLE ... AS SELECT ...` instead of `INSERT INTO`.
+
+  ## Examples
+
+      # Insert into an attached DuckLake table
+      Dux.attach(:lake, "ducklake:metadata.db", type: :ducklake, read_only: false)
+
+      Dux.from_parquet("s3://bucket/raw/*.parquet")
+      |> Dux.filter(col("status") == "active")
+      |> Dux.insert_into("lake.analytics.users")
+
+      # Create a new table from a pipeline
+      Dux.from_csv("/data/events.csv")
+      |> Dux.mutate(day: cast(timestamp, :date))
+      |> Dux.insert_into("lake.events", create: true)
+
+      # Insert into a local DuckDB table
+      Dux.from_query("SELECT 1 AS x")
+      |> Dux.insert_into("my_table", create: true)
+  """
+  def insert_into(%Dux{} = dux, table, opts \\ []) when is_binary(table) do
+    create? = Keyword.get(opts, :create, false)
+    meta = %{table: table, create: create?}
+
+    :telemetry.span([:dux, :io, :write], meta, fn ->
+      conn = Dux.Connection.get_conn()
+      Process.put(:dux_write_ref, extract_source_ref(dux))
+      {query_sql, source_setup} = Dux.QueryBuilder.build(dux, conn)
+
+      Enum.each(source_setup, fn setup_sql ->
+        Dux.Backend.execute(conn, setup_sql)
+      end)
+
+      sql =
+        if create? do
+          "CREATE TABLE #{table} AS #{query_sql}"
+        else
+          "INSERT INTO #{table} #{query_sql}"
+        end
+
+      case Adbc.Connection.query(conn, sql) do
+        {:ok, _} -> :ok
+        {:error, err} -> raise ArgumentError, "DuckDB insert failed: #{Exception.message(err)}"
+      end
+
+      Process.delete(:dux_write_ref)
+      {:ok, meta}
+    end)
+  end
+
   # ---------------------------------------------------------------------------
   # Cross-source (ATTACH)
   # ---------------------------------------------------------------------------

--- a/lib/dux/query_builder.ex
+++ b/lib/dux/query_builder.ex
@@ -119,6 +119,12 @@ defmodule Dux.QueryBuilder do
     {"SELECT * FROM read_parquet([#{file_list}]#{options})", []}
   end
 
+  # DuckLake files — resolved by coordinator from DuckLake file manifest
+  defp source_to_sql({:ducklake_files, files}, _db) do
+    file_list = Enum.map_join(files, ", ", &"'#{escape_sql_string(&1)}'")
+    {"SELECT * FROM read_parquet([#{file_list}])", []}
+  end
+
   defp source_to_sql({:csv, path, opts}, _db) do
     escaped = escape_sql_string(path)
     options = csv_read_options(opts)

--- a/lib/dux/remote/coordinator.ex
+++ b/lib/dux/remote/coordinator.ex
@@ -49,6 +49,10 @@ defmodule Dux.Remote.Coordinator do
       raise ArgumentError, "no workers available for distributed execution"
     end
 
+    # Resolve sources that can be partitioned at the coordinator level.
+    # DuckLake attached sources → file manifest for direct parquet reads.
+    pipeline = resolve_ducklake_source(pipeline)
+
     # Split pipeline: worker ops push down, coordinator ops apply post-merge
     %{
       worker_ops: worker_ops,
@@ -545,10 +549,83 @@ defmodule Dux.Remote.Coordinator do
     end)
   end
 
+  # ---------------------------------------------------------------------------
+  # DuckLake source resolution
+  # ---------------------------------------------------------------------------
+
+  # Resolve a DuckLake attached source into a list of backing Parquet file paths.
+  # The coordinator queries the DuckLake catalog's file manifest and replaces
+  # the {:attached, ...} source with {:ducklake_files, paths} so workers can
+  # read the underlying Parquet files directly — no DuckLake extension needed.
+  defp resolve_ducklake_source(%Dux{source: {:attached, db_name, table_name}} = pipeline) do
+    try_resolve_ducklake(pipeline, db_name, table_name)
+  end
+
+  defp resolve_ducklake_source(%Dux{source: {:attached, db_name, table_name, _opts}} = pipeline) do
+    try_resolve_ducklake(pipeline, db_name, table_name)
+  end
+
+  defp resolve_ducklake_source(pipeline), do: pipeline
+
+  defp try_resolve_ducklake(pipeline, db_name, table_name) do
+    conn = Dux.Connection.get_conn()
+    db_str = to_string(db_name)
+
+    case attached_db_type(conn, db_str) do
+      "ducklake" -> resolve_ducklake_files(pipeline, conn, db_str, table_name)
+      _ -> pipeline
+    end
+  end
+
+  defp attached_db_type(conn, db_name) do
+    sql = "SELECT type FROM pragma_database_list() WHERE name = '#{db_name}'"
+
+    case Adbc.Connection.query(conn, sql) do
+      {:ok, result} -> extract_first_value(Adbc.Result.materialize(result))
+      {:error, _} -> nil
+    end
+  end
+
+  defp resolve_ducklake_files(pipeline, conn, catalog, table_name) do
+    case list_ducklake_files(conn, catalog, table_name) do
+      [] -> pipeline
+      files -> %{pipeline | source: {:ducklake_files, files}}
+    end
+  end
+
+  defp list_ducklake_files(conn, catalog, table_name) do
+    sql = "SELECT data_file FROM ducklake_list_files('#{catalog}', '#{table_name}')"
+
+    case Adbc.Connection.query(conn, sql) do
+      {:ok, result} -> extract_column(Adbc.Result.materialize(result), "data_file")
+      {:error, _} -> []
+    end
+  end
+
+  defp extract_first_value(%{data: [col | _]}) do
+    case Enum.to_list(col) do
+      [val | _] -> val
+      _ -> nil
+    end
+  end
+
+  defp extract_first_value(_), do: nil
+
+  defp extract_column(%{data: columns}, name) do
+    Enum.find_value(columns, [], fn col ->
+      if col.field.name == name, do: Enum.to_list(col)
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+
   # A source is worker-safe if every worker can independently resolve it.
   # File paths, SQL queries, and inline lists are worker-safe.
   # Table refs ({:table, ResourceArc}) are node-local — only the coordinator has them.
   defp worker_safe_source?({:parquet, _}), do: true
+  defp worker_safe_source?({:parquet, _, _}), do: true
+  defp worker_safe_source?({:parquet_list, _, _}), do: true
+  defp worker_safe_source?({:ducklake_files, _}), do: true
   defp worker_safe_source?({:csv, _, _}), do: true
   defp worker_safe_source?({:ndjson, _, _}), do: true
   defp worker_safe_source?({:sql, _}), do: true

--- a/lib/dux/remote/partitioner.ex
+++ b/lib/dux/remote/partitioner.ex
@@ -28,6 +28,33 @@ defmodule Dux.Remote.Partitioner do
     end
   end
 
+  # DuckLake — resolve the file manifest and distribute as parquet reads.
+  # The coordinator resolves the DuckLake catalog into a {:ducklake_files, ...} source
+  # containing the list of backing Parquet paths. Workers read these directly.
+  defp assign_strategy(
+         %Dux{source: {:ducklake_files, files}} = pipeline,
+         workers,
+         :round_robin
+       ) do
+    partitions = chunk_round_robin(files, length(workers))
+
+    Enum.zip(workers, partitions)
+    |> Enum.map(fn {worker, file_group} ->
+      source =
+        case file_group do
+          [] -> {:parquet_list, [], []}
+          [single] -> {:parquet, single, []}
+          multiple -> {:parquet_list, multiple, []}
+        end
+
+      {worker, %{pipeline | source: source}}
+    end)
+    |> Enum.reject(fn
+      {_worker, %{source: {:parquet_list, [], _}}} -> true
+      _ -> false
+    end)
+  end
+
   # CSV with glob-like path — no splitting (CSV globs less common)
   defp assign_strategy(pipeline, workers, :round_robin) do
     replicate(pipeline, workers)

--- a/test/dux/coordinator_test.exs
+++ b/test/dux/coordinator_test.exs
@@ -114,7 +114,7 @@ defmodule Dux.CoordinatorTest do
       assert Enum.sort(total_files) == Enum.sort(files)
     end
 
-    test "single DuckLake file goes to one worker as parquet source" do
+    test "single DuckLake file goes to one worker, others dropped" do
       files = ["s3://bucket/data/file1.parquet"]
 
       pipeline = %Dux{
@@ -132,6 +132,59 @@ defmodule Dux.CoordinatorTest do
       assert length(assignments) == 1
       [{_worker, assigned}] = assignments
       assert assigned.source == {:parquet, "s3://bucket/data/file1.parquet", []}
+    end
+
+    test "more workers than files assigns one file per worker" do
+      files = ["s3://bucket/f1.parquet", "s3://bucket/f2.parquet"]
+
+      pipeline = %Dux{
+        source: {:ducklake_files, files},
+        ops: [],
+        names: [],
+        dtypes: %{},
+        groups: []
+      }
+
+      workers = [:w1, :w2, :w3, :w4, :w5]
+      assignments = Partitioner.assign(pipeline, workers)
+
+      # Only 2 workers get assignments; the rest are empty and filtered out
+      assert length(assignments) == 2
+
+      all_files =
+        Enum.flat_map(assignments, fn {_w, p} ->
+          case p.source do
+            {:parquet, f, _} -> [f]
+            {:parquet_list, f, _} -> f
+          end
+        end)
+
+      assert Enum.sort(all_files) == Enum.sort(files)
+    end
+
+    test "preserves pipeline ops through distribution" do
+      require Dux
+
+      files = ["s3://bucket/f1.parquet", "s3://bucket/f2.parquet"]
+
+      pipeline =
+        %Dux{
+          source: {:ducklake_files, files},
+          ops: [],
+          names: [],
+          dtypes: %{},
+          groups: []
+        }
+        |> Dux.filter_with("x > 10")
+        |> Dux.select([:x])
+
+      workers = [:w1, :w2]
+      assignments = Partitioner.assign(pipeline, workers)
+
+      # Ops should be preserved on each worker's pipeline
+      Enum.each(assignments, fn {_w, p} ->
+        assert length(p.ops) == 2
+      end)
     end
   end
 

--- a/test/dux/coordinator_test.exs
+++ b/test/dux/coordinator_test.exs
@@ -78,6 +78,63 @@ defmodule Dux.CoordinatorTest do
     end
   end
 
+  describe "Partitioner.assign/3 with ducklake_files" do
+    test "distributes DuckLake file list across workers as parquet sources" do
+      files = [
+        "s3://bucket/data/file1.parquet",
+        "s3://bucket/data/file2.parquet",
+        "s3://bucket/data/file3.parquet",
+        "s3://bucket/data/file4.parquet",
+        "s3://bucket/data/file5.parquet",
+        "s3://bucket/data/file6.parquet"
+      ]
+
+      pipeline = %Dux{
+        source: {:ducklake_files, files},
+        ops: [],
+        names: [],
+        dtypes: %{},
+        groups: []
+      }
+
+      workers = [:w1, :w2, :w3]
+      assignments = Partitioner.assign(pipeline, workers)
+
+      assert length(assignments) == 3
+
+      total_files =
+        Enum.flat_map(assignments, fn {_w, p} ->
+          case p.source do
+            {:parquet_list, f, _} -> f
+            {:parquet, f, _} -> [f]
+          end
+        end)
+
+      assert length(total_files) == 6
+      assert Enum.sort(total_files) == Enum.sort(files)
+    end
+
+    test "single DuckLake file goes to one worker as parquet source" do
+      files = ["s3://bucket/data/file1.parquet"]
+
+      pipeline = %Dux{
+        source: {:ducklake_files, files},
+        ops: [],
+        names: [],
+        dtypes: %{},
+        groups: []
+      }
+
+      workers = [:w1, :w2]
+      assignments = Partitioner.assign(pipeline, workers)
+
+      # Only 1 assignment — workers with no files are filtered out
+      assert length(assignments) == 1
+      [{_worker, assigned}] = assignments
+      assert assigned.source == {:parquet, "s3://bucket/data/file1.parquet", []}
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Merger unit tests
   # ---------------------------------------------------------------------------

--- a/test/dux/io_test.exs
+++ b/test/dux/io_test.exs
@@ -431,5 +431,76 @@ defmodule Dux.IOTest do
         File.rm(path)
       end
     end
+
+    test "insert_into with pipeline before write" do
+      require Dux
+
+      Dux.from_query("SELECT * FROM range(1, 11) t(x)")
+      |> Dux.filter(x > 5)
+      |> Dux.mutate(doubled: x * 2)
+      |> Dux.insert_into("__dux_insert_pipeline", create: true)
+
+      result =
+        Dux.from_query("SELECT * FROM __dux_insert_pipeline ORDER BY x")
+        |> Dux.to_columns()
+
+      assert result["x"] == [6, 7, 8, 9, 10]
+      assert result["doubled"] == [12, 14, 16, 18, 20]
+    after
+      conn = Dux.Connection.get_conn()
+      Adbc.Connection.query(conn, "DROP TABLE IF EXISTS __dux_insert_pipeline")
+    end
+
+    test "insert_into non-existent table without create raises" do
+      assert_raise ArgumentError, ~r/DuckDB insert failed/, fn ->
+        Dux.from_list([%{"x" => 1}])
+        |> Dux.insert_into("__dux_table_that_does_not_exist")
+      end
+    end
+
+    test "insert_into preserves null values" do
+      Dux.from_query("SELECT 1 AS x, NULL AS y UNION ALL SELECT NULL, 'hello'")
+      |> Dux.insert_into("__dux_insert_nulls", create: true)
+
+      result =
+        Dux.from_query("SELECT * FROM __dux_insert_nulls ORDER BY x")
+        |> Dux.to_columns()
+
+      assert nil in result["x"]
+      assert nil in result["y"]
+    after
+      conn = Dux.Connection.get_conn()
+      Adbc.Connection.query(conn, "DROP TABLE IF EXISTS __dux_insert_nulls")
+    end
+
+    test "insert_into with empty pipeline creates empty table" do
+      Dux.from_query("SELECT 1 AS x WHERE false")
+      |> Dux.insert_into("__dux_insert_empty", create: true)
+
+      assert Dux.from_query("SELECT * FROM __dux_insert_empty") |> Dux.n_rows() == 0
+    after
+      conn = Dux.Connection.get_conn()
+      Adbc.Connection.query(conn, "DROP TABLE IF EXISTS __dux_insert_empty")
+    end
+
+    test "multiple inserts accumulate rows" do
+      Dux.from_list([%{"x" => 1}])
+      |> Dux.insert_into("__dux_insert_multi", create: true)
+
+      Dux.from_list([%{"x" => 2}])
+      |> Dux.insert_into("__dux_insert_multi")
+
+      Dux.from_list([%{"x" => 3}])
+      |> Dux.insert_into("__dux_insert_multi")
+
+      result =
+        Dux.from_query("SELECT * FROM __dux_insert_multi ORDER BY x")
+        |> Dux.to_columns()
+
+      assert result == %{"x" => [1, 2, 3]}
+    after
+      conn = Dux.Connection.get_conn()
+      Adbc.Connection.query(conn, "DROP TABLE IF EXISTS __dux_insert_multi")
+    end
   end
 end

--- a/test/dux/io_test.exs
+++ b/test/dux/io_test.exs
@@ -374,4 +374,62 @@ defmodule Dux.IOTest do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # insert_into
+  # ---------------------------------------------------------------------------
+
+  describe "insert_into" do
+    test "create: true creates a new table from pipeline" do
+      require Dux
+
+      Dux.from_list([%{"x" => 1}, %{"x" => 2}, %{"x" => 3}])
+      |> Dux.filter(x > 1)
+      |> Dux.insert_into("__dux_insert_test_create", create: true)
+
+      result =
+        Dux.from_query("SELECT * FROM __dux_insert_test_create ORDER BY x")
+        |> Dux.to_columns()
+
+      assert result == %{"x" => [2, 3]}
+    after
+      conn = Dux.Connection.get_conn()
+      Adbc.Connection.query(conn, "DROP TABLE IF EXISTS __dux_insert_test_create")
+    end
+
+    test "inserts into an existing table" do
+      conn = Dux.Connection.get_conn()
+      Adbc.Connection.query!(conn, "CREATE TABLE __dux_insert_test_existing (x BIGINT)")
+      Adbc.Connection.query!(conn, "INSERT INTO __dux_insert_test_existing VALUES (0)")
+
+      Dux.from_list([%{"x" => 1}, %{"x" => 2}])
+      |> Dux.insert_into("__dux_insert_test_existing")
+
+      result =
+        Dux.from_query("SELECT * FROM __dux_insert_test_existing ORDER BY x")
+        |> Dux.to_columns()
+
+      assert result == %{"x" => [0, 1, 2]}
+    after
+      conn = Dux.Connection.get_conn()
+      Adbc.Connection.query(conn, "DROP TABLE IF EXISTS __dux_insert_test_existing")
+    end
+
+    test "insert_into with attached DuckDB database" do
+      path = tmp_path("insert_attached.duckdb")
+
+      try do
+        Dux.attach(:insert_test_db, path, type: :duckdb, read_only: false)
+
+        Dux.from_list([%{"a" => 10, "b" => "hello"}])
+        |> Dux.insert_into("insert_test_db.main.insert_target", create: true)
+
+        result = Dux.from_attached(:insert_test_db, "insert_target") |> Dux.to_rows()
+        assert result == [%{"a" => 10, "b" => "hello"}]
+      after
+        Dux.detach(:insert_test_db)
+        File.rm(path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- **`Dux.insert_into/3`** — new verb for writing pipeline results into any table DuckDB can write to (local, attached Postgres, DuckLake, etc.). Supports `create: true` for `CREATE TABLE AS` semantics.
- **Distributed DuckLake reads** — the coordinator now resolves DuckLake attached sources by querying `ducklake_list_files()` for the backing Parquet file manifest, then distributes those files across workers. Workers read Parquet directly — no DuckLake extension needed on worker nodes.

### insert_into examples

```elixir
# Write to an attached DuckLake table
Dux.attach(:lake, "ducklake:metadata.db", type: :ducklake, read_only: false)

Dux.from_parquet("s3://bucket/raw/*.parquet")
|> Dux.filter(col("status") == "active")
|> Dux.insert_into("lake.analytics.users")

# Create a new table from a pipeline
Dux.from_csv("/data/events.csv")
|> Dux.insert_into("lake.events", create: true)
```

### Distributed DuckLake read flow

1. Coordinator detects `{:attached, ...}` source is DuckLake (via `pragma_database_list`)
2. Queries `ducklake_list_files()` to get backing Parquet paths
3. Distributes file list across workers via Partitioner
4. Workers scan Parquet directly — standard `read_parquet()`, no DuckLake attach needed

## Test plan

- [x] `insert_into` with `create: true` creates table from pipeline
- [x] `insert_into` appends to existing table
- [x] `insert_into` works with attached DuckDB database
- [x] Partitioner distributes DuckLake file list across workers as parquet sources
- [x] Single-file DuckLake source assigned to one worker
- [x] All existing tests pass (566 tests, 0 failures)
- [x] Credo clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)