### PR TITLE
chore: expand CI matrix to full OTP × Elixir lattice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - otp: "27"
-            elixir: "1.18"
-          - otp: "28"
-            elixir: "1.19"
+        otp: ["27", "28"]
+        elixir: ["1.18", "1.19"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Expand CI from 2 jobs (diagonal only) to 4 jobs (full lattice):

| | Elixir 1.18 | Elixir 1.19 |
|---|---|---|
| **OTP 27** | ✅ new | ✅ existing |
| **OTP 28** | ✅ new | ✅ existing |

Catches compatibility issues when OTP/Elixir versions are crossed (e.g. Elixir 1.18 on OTP 28, Elixir 1.19 on OTP 27).

## Test plan

- [x] CI runs all four combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)