### PR TITLE
feat: Hive partition pruning in distributed reads

### DIFF
--- a/lib/dux/remote/partition_pruner.ex
+++ b/lib/dux/remote/partition_pruner.ex
@@ -1,0 +1,124 @@
+defmodule Dux.Remote.PartitionPruner do
+  @moduledoc false
+
+  # Prunes Hive-partitioned Parquet files based on pipeline filter ops.
+  #
+  # Given a list of file paths like:
+  #   ["s3://bucket/year=2024/month=01/data.parquet",
+  #    "s3://bucket/year=2024/month=02/data.parquet",
+  #    "s3://bucket/year=2023/month=12/data.parquet"]
+  #
+  # And filter ops like:
+  #   [{:filter, "\"year\" = 2024"}]
+  #
+  # Returns only the files where year=2024.
+  #
+  # Only handles simple equality predicates on partition columns.
+  # Complex expressions are ignored (safe — we just read more data).
+
+  @doc """
+  Prune files whose Hive partition values don't match filter predicates.
+
+  Returns the filtered list of files. If no partition filters can be
+  extracted, returns the original list unchanged.
+  """
+  def prune(files, ops) do
+    filters = extract_partition_filters(ops)
+
+    if filters == [] do
+      files
+    else
+      Enum.filter(files, fn file ->
+        partitions = extract_hive_partitions(file)
+        matches_all?(partitions, filters)
+      end)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Hive partition extraction from file paths
+  # ---------------------------------------------------------------------------
+
+  # Extract key=value pairs from a file path.
+  # "s3://bucket/year=2024/month=01/data.parquet" → %{"year" => "2024", "month" => "01"}
+  @doc false
+  def extract_hive_partitions(path) do
+    path
+    |> String.split("/")
+    |> Enum.flat_map(fn segment ->
+      case String.split(segment, "=", parts: 2) do
+        [key, value] when key != "" and value != "" -> [{key, value}]
+        _ -> []
+      end
+    end)
+    |> Map.new()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Filter predicate extraction from ops
+  # ---------------------------------------------------------------------------
+
+  # Extract simple equality predicates from filter ops that match partition columns.
+  # Returns [{column_name, value}] for predicates like:
+  #   "year" = 2024        → {"year", "2024"}
+  #   "month" = '01'       → {"month", "01"}
+  #   year = 2024          → {"year", "2024"}
+  defp extract_partition_filters(ops) do
+    ops
+    |> Enum.flat_map(fn
+      {:filter, expr} when is_binary(expr) -> parse_equality_predicates(expr)
+      _ -> []
+    end)
+  end
+
+  # Parse simple equality predicates from a SQL WHERE clause string.
+  # Handles: col = val, "col" = val, col = 'val', and AND-connected predicates.
+  defp parse_equality_predicates(expr) do
+    # Split on AND (case-insensitive) to handle compound filters
+    expr
+    |> String.split(~r/\bAND\b/i)
+    |> Enum.flat_map(&parse_single_predicate/1)
+  end
+
+  defp parse_single_predicate(predicate) do
+    trimmed = String.trim(predicate)
+
+    # Match patterns like: "col" = val, col = val, "col" = 'val'
+    # Captures: optional quotes around column name, = operator, value
+    case Regex.run(
+           ~r/^"?([a-zA-Z_][a-zA-Z0-9_]*)"?\s*=\s*(.+)$/,
+           trimmed
+         ) do
+      [_, column, raw_value] ->
+        value = clean_value(String.trim(raw_value))
+        [{column, value}]
+
+      _ ->
+        []
+    end
+  end
+
+  # Strip quotes and whitespace from a SQL value literal
+  defp clean_value(val) do
+    val
+    |> String.trim("'")
+    |> String.trim("\"")
+    |> String.trim()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Matching
+  # ---------------------------------------------------------------------------
+
+  # Check if a file's partition values match ALL filter predicates.
+  # If the file has no partition for a given filter column, it passes
+  # (the filter may apply to a non-partition column).
+  defp matches_all?(partitions, filters) do
+    Enum.all?(filters, fn {col, expected} ->
+      case Map.get(partitions, col) do
+        nil -> true
+        actual -> actual == expected
+      end
+    end)
+  end
+end

--- a/lib/dux/remote/partitioner.ex
+++ b/lib/dux/remote/partitioner.ex
@@ -1,6 +1,8 @@
 defmodule Dux.Remote.Partitioner do
   @moduledoc false
 
+  alias Dux.Remote.PartitionPruner
+
   # Assigns data partitions to workers.
   #
   # For Parquet glob sources and DuckLake file manifests, splits files
@@ -57,6 +59,18 @@ defmodule Dux.Remote.Partitioner do
   # ---------------------------------------------------------------------------
 
   defp distribute_parquet_files(files, workers, pipeline, source_opts, assign_opts) do
+    # Prune files whose Hive partition values don't match pipeline filters
+    files = PartitionPruner.prune(files, pipeline.ops)
+
+    if files == [] do
+      # All files pruned — return empty result from one worker
+      [{hd(workers), %{pipeline | source: {:sql, "SELECT 1 WHERE false"}}}]
+    else
+      distribute_pruned_files(files, workers, pipeline, source_opts, assign_opts)
+    end
+  end
+
+  defp distribute_pruned_files(files, workers, pipeline, source_opts, assign_opts) do
     files_with_sizes = fetch_file_sizes(files, assign_opts)
 
     assignments =

--- a/test/dux/coordinator_test.exs
+++ b/test/dux/coordinator_test.exs
@@ -307,6 +307,116 @@ defmodule Dux.CoordinatorTest do
     end
   end
 
+  describe "Partitioner partition pruning" do
+    test "prunes Hive-partitioned files based on filter ops" do
+      dir = tmp_path("hive_pruning")
+      File.mkdir_p!(dir)
+
+      try do
+        # Create Hive-partitioned structure
+        for year <- [2023, 2024], month <- ["01", "02"] do
+          part_dir = Path.join([dir, "year=#{year}", "month=#{month}"])
+          File.mkdir_p!(part_dir)
+
+          Dux.from_list([%{"x" => year * 100 + String.to_integer(month)}])
+          |> Dux.to_parquet(Path.join(part_dir, "data.parquet"))
+        end
+
+        pipeline =
+          Dux.from_parquet(Path.join(dir, "**/*.parquet"))
+          |> Dux.filter_with("year = 2024")
+
+        workers = [:w1, :w2]
+        assignments = Partitioner.assign(pipeline, workers)
+
+        # Should only have year=2024 files (2 files), not year=2023
+        all_files =
+          Enum.flat_map(assignments, fn {_w, p} ->
+            case p.source do
+              {:parquet, f, _} -> [f]
+              {:parquet_list, f, _} -> f
+            end
+          end)
+
+        assert length(all_files) == 2
+        assert Enum.all?(all_files, &String.contains?(&1, "year=2024"))
+      after
+        File.rm_rf!(dir)
+      end
+    end
+
+    test "prunes on multiple partition columns" do
+      dir = tmp_path("hive_multi_prune")
+      File.mkdir_p!(dir)
+
+      try do
+        for year <- [2023, 2024], month <- ["01", "02"] do
+          part_dir = Path.join([dir, "year=#{year}", "month=#{month}"])
+          File.mkdir_p!(part_dir)
+
+          Dux.from_list([%{"x" => 1}])
+          |> Dux.to_parquet(Path.join(part_dir, "data.parquet"))
+        end
+
+        pipeline =
+          Dux.from_parquet(Path.join(dir, "**/*.parquet"))
+          |> Dux.filter_with("year = 2024 AND month = '01'")
+
+        workers = [:w1, :w2]
+        assignments = Partitioner.assign(pipeline, workers)
+
+        all_files =
+          Enum.flat_map(assignments, fn {_w, p} ->
+            case p.source do
+              {:parquet, f, _} -> [f]
+              {:parquet_list, f, _} -> f
+            end
+          end)
+
+        assert length(all_files) == 1
+        assert hd(all_files) |> String.contains?("year=2024")
+        assert hd(all_files) |> String.contains?("month=01")
+      after
+        File.rm_rf!(dir)
+      end
+    end
+
+    test "no pruning when filter doesn't match partition columns" do
+      dir = tmp_path("hive_no_prune")
+      File.mkdir_p!(dir)
+
+      try do
+        for year <- [2023, 2024] do
+          part_dir = Path.join(dir, "year=#{year}")
+          File.mkdir_p!(part_dir)
+
+          Dux.from_list([%{"x" => year}])
+          |> Dux.to_parquet(Path.join(part_dir, "data.parquet"))
+        end
+
+        pipeline =
+          Dux.from_parquet(Path.join(dir, "**/*.parquet"))
+          |> Dux.filter_with("x > 100")
+
+        workers = [:w1, :w2]
+        assignments = Partitioner.assign(pipeline, workers)
+
+        all_files =
+          Enum.flat_map(assignments, fn {_w, p} ->
+            case p.source do
+              {:parquet, f, _} -> [f]
+              {:parquet_list, f, _} -> f
+            end
+          end)
+
+        # x is not a partition column, so all files pass through
+        assert length(all_files) == 2
+      after
+        File.rm_rf!(dir)
+      end
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Merger unit tests
   # ---------------------------------------------------------------------------

--- a/test/dux/partition_pruner_test.exs
+++ b/test/dux/partition_pruner_test.exs
@@ -1,0 +1,163 @@
+defmodule Dux.Remote.PartitionPrunerTest do
+  use ExUnit.Case, async: true
+
+  alias Dux.Remote.PartitionPruner
+
+  # ---------------------------------------------------------------------------
+  # Hive partition extraction
+  # ---------------------------------------------------------------------------
+
+  describe "extract_hive_partitions/1" do
+    test "extracts key=value pairs from path segments" do
+      assert PartitionPruner.extract_hive_partitions(
+               "s3://bucket/year=2024/month=01/data.parquet"
+             ) == %{"year" => "2024", "month" => "01"}
+    end
+
+    test "handles local paths" do
+      assert PartitionPruner.extract_hive_partitions(
+               "/data/output/region=US/day=2024-01-15/part_0.parquet"
+             ) == %{"region" => "US", "day" => "2024-01-15"}
+    end
+
+    test "returns empty map for non-partitioned paths" do
+      assert PartitionPruner.extract_hive_partitions("s3://bucket/data.parquet") == %{}
+      assert PartitionPruner.extract_hive_partitions("/tmp/flat/file.parquet") == %{}
+    end
+
+    test "ignores segments that aren't key=value" do
+      assert PartitionPruner.extract_hive_partitions("s3://bucket/data/year=2024/file.parquet") ==
+               %{"year" => "2024"}
+    end
+
+    test "handles multiple = in value" do
+      # "key=val=ue" → key="val=ue" — split only on first =
+      # Actually our split uses parts: 2, so this works
+      assert PartitionPruner.extract_hive_partitions("/data/tag=a=b/file.parquet") ==
+               %{"tag" => "a=b"}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Pruning
+  # ---------------------------------------------------------------------------
+
+  describe "prune/2" do
+    test "prunes files that don't match equality filter" do
+      files = [
+        "/data/year=2024/month=01/a.parquet",
+        "/data/year=2024/month=02/b.parquet",
+        "/data/year=2023/month=12/c.parquet"
+      ]
+
+      ops = [{:filter, "\"year\" = 2024"}]
+      result = PartitionPruner.prune(files, ops)
+
+      assert length(result) == 2
+      assert Enum.all?(result, &String.contains?(&1, "year=2024"))
+    end
+
+    test "prunes on multiple partition columns" do
+      files = [
+        "/data/year=2024/month=01/a.parquet",
+        "/data/year=2024/month=02/b.parquet",
+        "/data/year=2023/month=01/c.parquet"
+      ]
+
+      ops = [{:filter, "\"year\" = 2024 AND \"month\" = '01'"}]
+      result = PartitionPruner.prune(files, ops)
+
+      assert result == ["/data/year=2024/month=01/a.parquet"]
+    end
+
+    test "handles unquoted column names" do
+      files = [
+        "/data/year=2024/a.parquet",
+        "/data/year=2023/b.parquet"
+      ]
+
+      ops = [{:filter, "year = 2024"}]
+      result = PartitionPruner.prune(files, ops)
+
+      assert result == ["/data/year=2024/a.parquet"]
+    end
+
+    test "passes through files when filter column is not a partition column" do
+      files = [
+        "/data/year=2024/a.parquet",
+        "/data/year=2023/b.parquet"
+      ]
+
+      # "status" is not a partition column — all files pass
+      ops = [{:filter, "status = 'active'"}]
+      result = PartitionPruner.prune(files, ops)
+
+      assert result == files
+    end
+
+    test "passes through all files when no filter ops" do
+      files = ["/data/year=2024/a.parquet", "/data/year=2023/b.parquet"]
+      assert PartitionPruner.prune(files, []) == files
+    end
+
+    test "passes through all files when ops don't contain filters" do
+      files = ["/data/year=2024/a.parquet"]
+      ops = [{:mutate, "x * 2 AS doubled"}, {:select, [:x]}]
+      assert PartitionPruner.prune(files, ops) == files
+    end
+
+    test "handles non-partitioned files mixed with partitioned" do
+      files = [
+        "/data/year=2024/a.parquet",
+        "/data/flat_file.parquet",
+        "/data/year=2023/b.parquet"
+      ]
+
+      ops = [{:filter, "year = 2024"}]
+      result = PartitionPruner.prune(files, ops)
+
+      # flat_file has no year partition → passes through (safe)
+      assert "/data/year=2024/a.parquet" in result
+      assert "/data/flat_file.parquet" in result
+      assert "/data/year=2023/b.parquet" not in result
+    end
+
+    test "handles multiple separate filter ops" do
+      files = [
+        "/data/year=2024/month=01/a.parquet",
+        "/data/year=2024/month=02/b.parquet",
+        "/data/year=2023/month=01/c.parquet"
+      ]
+
+      # Two separate filter ops (as opposed to AND in one string)
+      ops = [{:filter, "year = 2024"}, {:filter, "month = '01'"}]
+      result = PartitionPruner.prune(files, ops)
+
+      assert result == ["/data/year=2024/month=01/a.parquet"]
+    end
+
+    test "can prune all files" do
+      files = [
+        "/data/year=2023/a.parquet",
+        "/data/year=2022/b.parquet"
+      ]
+
+      ops = [{:filter, "year = 2024"}]
+      result = PartitionPruner.prune(files, ops)
+
+      assert result == []
+    end
+
+    test "handles string values with single quotes" do
+      files = [
+        "/data/region=US/a.parquet",
+        "/data/region=EU/b.parquet"
+      ]
+
+      ops = [{:filter, "region = 'US'"}]
+      result = PartitionPruner.prune(files, ops)
+
+      assert result == ["/data/region=US/a.parquet"]
+    end
+  end
+end

--- a/test/dux/partitioner_peer_test.exs
+++ b/test/dux/partitioner_peer_test.exs
@@ -254,6 +254,97 @@ defmodule Dux.PartitionerPeerTest do
   end
 
   # ---------------------------------------------------------------------------
+  # Hive partition pruning across peers
+  # ---------------------------------------------------------------------------
+
+  describe "partition pruning across peer workers" do
+    test "reads only matching partitions from Hive-partitioned data" do
+      dir = tmp_path("hive_peer")
+      File.mkdir_p!(dir)
+
+      {peer1, node1} = start_peer(:hive_prune1)
+      {peer2, node2} = start_peer(:hive_prune2)
+
+      try do
+        # Create Hive-partitioned dataset: year=2023 and year=2024
+        for year <- [2023, 2024], month <- 1..3 do
+          part_dir =
+            Path.join([dir, "year=#{year}", "month=#{String.pad_leading("#{month}", 2, "0")}"])
+
+          File.mkdir_p!(part_dir)
+
+          rows = for i <- 1..100, do: %{"value" => year * 1000 + month * 10 + i}
+
+          Dux.from_list(rows)
+          |> Dux.to_parquet(Path.join(part_dir, "data.parquet"))
+        end
+
+        {:ok, w1} = start_worker_on(node1)
+        {:ok, w2} = start_worker_on(node2)
+        Process.sleep(200)
+
+        # Filter to year=2024 — should prune year=2023 files
+        result =
+          Dux.from_parquet(Path.join(dir, "**/*.parquet"))
+          |> Dux.distribute([w1, w2])
+          |> Dux.filter_with("year = 2024")
+          |> Dux.summarise_with(n: "COUNT(*)", min_v: "MIN(value)", max_v: "MAX(value)")
+          |> Dux.to_rows()
+
+        row = hd(result)
+        # 3 months × 100 rows = 300 rows for year=2024
+        assert row["n"] == 300
+        # All values should be in the 2024xxx range
+        assert row["min_v"] >= 2_024_000
+        assert row["max_v"] < 2_025_000
+      after
+        :peer.stop(peer1)
+        :peer.stop(peer2)
+        File.rm_rf!(dir)
+      end
+    end
+
+    test "pruned distributed result matches local result" do
+      dir = tmp_path("hive_peer_match")
+      File.mkdir_p!(dir)
+
+      {peer1, node1} = start_peer(:hive_match1)
+      {peer2, node2} = start_peer(:hive_match2)
+
+      try do
+        for region <- ["US", "EU", "APAC"] do
+          part_dir = Path.join(dir, "region=#{region}")
+          File.mkdir_p!(part_dir)
+
+          rows = for i <- 1..50, do: %{"amount" => i * 10, "region_col" => region}
+
+          Dux.from_list(rows)
+          |> Dux.to_parquet(Path.join(part_dir, "data.parquet"))
+        end
+
+        {:ok, w1} = start_worker_on(node1)
+        {:ok, w2} = start_worker_on(node2)
+        Process.sleep(200)
+
+        query =
+          Dux.from_parquet(Path.join(dir, "**/*.parquet"))
+          |> Dux.filter_with("region = 'US'")
+          |> Dux.summarise_with(total: "SUM(amount)", n: "COUNT(*)")
+
+        local = query |> Dux.to_rows()
+        distributed = query |> Dux.distribute([w1, w2]) |> Dux.to_rows()
+
+        assert hd(local)["total"] == hd(distributed)["total"]
+        assert hd(local)["n"] == hd(distributed)["n"]
+      after
+        :peer.stop(peer1)
+        :peer.stop(peer2)
+        File.rm_rf!(dir)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Sad path
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

New `Dux.Remote.PartitionPruner` module that skips Parquet files whose Hive partition values don't match pipeline filter predicates. Integrated into the Partitioner before size-balanced assignment.

### How it works

Given files like `s3://bucket/year=2024/month=01/data.parquet` and a filter `year = 2024`, the pruner:

1. Parses `key=value` pairs from file path segments
2. Extracts simple equality predicates from `{:filter, sql}` ops
3. Skips files where partition values don't match

```
Before: 6 files (year=2023 × 3 months + year=2024 × 3 months) → all 6 distributed
After:  filter(year = 2024) → only 3 files distributed, 3 skipped
```

### What it handles
- Quoted and unquoted column names (`"year" = 2024`, `year = 2024`)
- String values (`region = 'US'`)
- AND-connected predicates (`year = 2024 AND month = '01'`)
- Multiple separate filter ops
- Mixed partitioned + non-partitioned files (non-partitioned files pass through safely)

### What it doesn't handle (safe — just reads more data)
- OR predicates, IN lists, range comparisons
- Complex expressions, function calls
- Non-Hive partition schemes

## Test plan

- [x] 15 unit tests for `PartitionPruner` (extraction, pruning, edge cases)
- [x] 3 integration tests in coordinator (Hive dirs on disk, single/multi-column, non-partition filter)
- [x] 2 `:peer` tests (end-to-end pruning with real distributed workers + Hive-partitioned Parquet)
- [x] 596 non-distributed tests pass, Credo clean
- [x] 7 peer tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)