### PR TITLE
feat: distributed writes — workers write directly to storage

### DIFF
--- a/lib/dux.ex
+++ b/lib/dux.ex
@@ -1679,6 +1679,11 @@ defmodule Dux do
   defp encode_param(false), do: "false"
   defp encode_param(nil), do: "NULL"
 
+  defp write_copy(%Dux{workers: workers} = dux, path, format, opts)
+       when is_list(workers) and workers != [] do
+    distributed_write(dux, path, format, opts)
+  end
+
   defp write_copy(%Dux{} = dux, path, format, opts) do
     fmt_atom = format |> String.downcase() |> String.to_atom()
     meta = %{format: fmt_atom, path: path}
@@ -1704,6 +1709,97 @@ defmodule Dux do
       Process.delete(:dux_write_ref)
       {:ok, meta}
     end)
+  end
+
+  defp distributed_write(%Dux{workers: workers} = dux, base_path, format, opts) do
+    alias Dux.Remote.{Partitioner, Worker}
+    require Logger
+
+    fmt_atom = format |> String.downcase() |> String.to_atom()
+    ext = format_extension(format)
+    copy_opts = build_copy_options(format, opts)
+    n_workers = length(workers)
+    meta = %{format: fmt_atom, path: base_path, n_workers: n_workers}
+
+    :telemetry.span([:dux, :distributed, :write], meta, fn ->
+      # Warn if output directory is non-empty
+      warn_if_non_empty(base_path)
+
+      # Partition the source across workers
+      pipeline = %{dux | workers: nil}
+      assignments = Partitioner.assign(pipeline, workers)
+
+      # Fan out: each worker writes its partition to a unique file
+      results = fan_out_writes(assignments, base_path, ext, copy_opts, n_workers)
+      files = handle_write_results(results, n_workers, base_path)
+
+      {:ok, Map.merge(meta, %{files: files, n_files: length(files)})}
+    end)
+  end
+
+  defp fan_out_writes(assignments, base_path, ext, copy_opts, n_workers) do
+    alias Dux.Remote.Worker
+
+    assignments
+    |> Enum.with_index()
+    |> Task.async_stream(
+      fn {{worker, worker_pipeline}, idx} ->
+        unique = :erlang.unique_integer([:positive])
+        file_path = Path.join(base_path, "part_#{idx}_#{unique}.#{ext}")
+        {worker, Worker.write(worker, worker_pipeline, file_path, copy_opts)}
+      end,
+      max_concurrency: n_workers,
+      timeout: :infinity
+    )
+    |> Enum.map(fn {:ok, result} -> result end)
+  end
+
+  defp handle_write_results(results, n_workers, base_path) do
+    require Logger
+
+    {successes, failures} =
+      Enum.split_with(results, fn {_w, result} -> match?({:ok, _}, result) end)
+
+    if successes == [] and failures != [] do
+      reasons = Enum.map(failures, fn {_w, {:error, r}} -> r end)
+      raise ArgumentError, "all workers failed distributed write: #{inspect(reasons)}"
+    end
+
+    if failures != [] do
+      Logger.warning(
+        "#{length(failures)} of #{n_workers} workers failed during distributed write to #{base_path}"
+      )
+    end
+
+    Enum.map(successes, fn {_w, {:ok, path}} -> path end)
+  end
+
+  defp format_extension("CSV"), do: "csv"
+  defp format_extension("PARQUET"), do: "parquet"
+  defp format_extension("JSON"), do: "ndjson"
+
+  defp warn_if_non_empty(path) do
+    require Logger
+
+    cond do
+      String.starts_with?(path, "s3://") or String.starts_with?(path, "http") ->
+        # Skip check for remote paths — glob would be expensive
+        :ok
+
+      File.dir?(path) ->
+        case File.ls(path) do
+          {:ok, entries} when entries != [] ->
+            Logger.warning(
+              "distributed write target #{path} is not empty (#{length(entries)} existing entries)"
+            )
+
+          _ ->
+            :ok
+        end
+
+      true ->
+        :ok
+    end
   end
 
   defp build_copy_options("CSV", opts) do

--- a/lib/dux/remote/worker.ex
+++ b/lib/dux/remote/worker.ex
@@ -103,6 +103,18 @@ defmodule Dux.Remote.Worker do
   end
 
   @doc """
+  Execute a pipeline and write the results directly to a file.
+
+  The worker compiles the pipeline to SQL, then runs
+  `COPY (query) TO 'path' (format_opts)`. Returns `{:ok, path}` or
+  `{:error, reason}`.
+  """
+  def write(worker, %Dux{} = pipeline, path, copy_opts_sql, timeout \\ :infinity)
+      when is_binary(path) and is_binary(copy_opts_sql) do
+    GenServer.call(worker, {:write, pipeline, path, copy_opts_sql}, timeout)
+  end
+
+  @doc """
   Get worker info (node, connection status).
   """
   def info(worker) do
@@ -260,6 +272,32 @@ defmodule Dux.Remote.Worker do
       end
 
     {:reply, result, %{state | tables: tables}}
+  end
+
+  @impl true
+  def handle_call({:write, %Dux{} = pipeline, path, copy_opts_sql}, _from, %{conn: conn} = state) do
+    result =
+      try do
+        source_ref = extract_source_ref(pipeline)
+        {sql, source_setup} = Dux.QueryBuilder.build(pipeline, conn)
+        Enum.each(source_setup, fn s -> Dux.Backend.execute(conn, s) end)
+
+        escaped_path = String.replace(path, "'", "''")
+        copy_sql = "COPY (#{sql}) TO '#{escaped_path}' (#{copy_opts_sql})"
+
+        result =
+          case Adbc.Connection.query(conn, copy_sql) do
+            {:ok, _} -> {:ok, path}
+            {:error, err} -> {:error, Exception.message(err)}
+          end
+
+        :erlang.phash2(source_ref, 1)
+        result
+      rescue
+        e -> {:error, Exception.message(e)}
+      end
+
+    {:reply, result, state}
   end
 
   @impl true

--- a/test/dux/distributed_write_peer_test.exs
+++ b/test/dux/distributed_write_peer_test.exs
@@ -1,0 +1,264 @@
+defmodule Dux.DistributedWritePeerTest do
+  use ExUnit.Case, async: false
+  require Dux
+
+  alias Dux.Remote.Worker
+
+  @moduletag :distributed
+  @moduletag timeout: 120_000
+
+  @tmp_dir System.tmp_dir!()
+
+  # ---------------------------------------------------------------------------
+  # Peer helpers
+  # ---------------------------------------------------------------------------
+
+  defp start_peer(name) do
+    unless Node.alive?() do
+      raise "distributed tests require a named node — see test_helper.exs"
+    end
+
+    pa_args =
+      :code.get_path()
+      |> Enum.flat_map(fn path -> [~c"-pa", path] end)
+
+    {:ok, peer, node} = :peer.start(%{name: name, args: pa_args})
+    {:ok, _apps} = :erpc.call(node, Application, :ensure_all_started, [:dux])
+    {peer, node}
+  end
+
+  defp start_worker_on(node) do
+    :erpc.call(node, DynamicSupervisor, :start_child, [
+      Dux.DynamicSupervisor,
+      %{id: Worker, start: {Worker, :start_link, [[]]}, restart: :temporary}
+    ])
+  end
+
+  defp tmp_path(name) do
+    Path.join(@tmp_dir, "dux_dw_peer_#{System.unique_integer([:positive])}_#{name}")
+  end
+
+  # ---------------------------------------------------------------------------
+  # Distributed writes: to_parquet
+  # ---------------------------------------------------------------------------
+
+  describe "distributed to_parquet across peer workers" do
+    test "writes partitioned parquet files in parallel" do
+      input_dir = tmp_path("dw_input")
+      output_dir = tmp_path("dw_output")
+      File.mkdir_p!(input_dir)
+      File.mkdir_p!(output_dir)
+
+      {peer1, node1} = start_peer(:dw_parq1)
+      {peer2, node2} = start_peer(:dw_parq2)
+
+      try do
+        # Create input data as 4 parquet files
+        for i <- 1..4 do
+          rows = for j <- 1..25, do: %{"x" => (i - 1) * 25 + j}
+
+          Dux.from_list(rows)
+          |> Dux.to_parquet(Path.join(input_dir, "part_#{i}.parquet"))
+        end
+
+        {:ok, w1} = start_worker_on(node1)
+        {:ok, w2} = start_worker_on(node2)
+        Process.sleep(200)
+
+        # Distributed write: each worker writes its partition
+        Dux.from_parquet(Path.join(input_dir, "*.parquet"))
+        |> Dux.distribute([w1, w2])
+        |> Dux.to_parquet(output_dir)
+
+        # Verify: read back the output and check correctness
+        result =
+          Dux.from_parquet(Path.join(output_dir, "*.parquet"))
+          |> Dux.summarise_with(n: "COUNT(*)", total: "SUM(x)")
+          |> Dux.to_rows()
+
+        row = hd(result)
+        assert row["n"] == 100
+        assert row["total"] == div(100 * 101, 2)
+
+        # Should have created 2 files (one per worker)
+        output_files = Path.wildcard(Path.join(output_dir, "*.parquet"))
+        assert length(output_files) == 2
+      after
+        :peer.stop(peer1)
+        :peer.stop(peer2)
+        File.rm_rf!(input_dir)
+        File.rm_rf!(output_dir)
+      end
+    end
+
+    test "distributed write with filter + mutate pipeline" do
+      input_dir = tmp_path("dw_pipeline_input")
+      output_dir = tmp_path("dw_pipeline_output")
+      File.mkdir_p!(input_dir)
+      File.mkdir_p!(output_dir)
+
+      {peer1, node1} = start_peer(:dw_pipe1)
+      {peer2, node2} = start_peer(:dw_pipe2)
+
+      try do
+        for i <- 1..4 do
+          rows = for j <- 1..25, do: %{"x" => (i - 1) * 25 + j}
+
+          Dux.from_list(rows)
+          |> Dux.to_parquet(Path.join(input_dir, "part_#{i}.parquet"))
+        end
+
+        {:ok, w1} = start_worker_on(node1)
+        {:ok, w2} = start_worker_on(node2)
+        Process.sleep(200)
+
+        Dux.from_parquet(Path.join(input_dir, "*.parquet"))
+        |> Dux.distribute([w1, w2])
+        |> Dux.filter_with("x > 50")
+        |> Dux.mutate_with(doubled: "x * 2")
+        |> Dux.to_parquet(output_dir)
+
+        result =
+          Dux.from_parquet(Path.join(output_dir, "*.parquet"))
+          |> Dux.sort_by(:x)
+          |> Dux.to_columns()
+
+        assert length(result["x"]) == 50
+        assert hd(result["x"]) == 51
+        assert List.last(result["x"]) == 100
+        assert hd(result["doubled"]) == 102
+      after
+        :peer.stop(peer1)
+        :peer.stop(peer2)
+        File.rm_rf!(input_dir)
+        File.rm_rf!(output_dir)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Distributed writes: to_csv
+  # ---------------------------------------------------------------------------
+
+  describe "distributed to_csv across peer workers" do
+    test "writes CSV files in parallel" do
+      input_dir = tmp_path("dw_csv_input")
+      output_dir = tmp_path("dw_csv_output")
+      File.mkdir_p!(input_dir)
+      File.mkdir_p!(output_dir)
+
+      {peer1, node1} = start_peer(:dw_csv1)
+      {peer2, node2} = start_peer(:dw_csv2)
+
+      try do
+        for i <- 1..4 do
+          rows = for j <- 1..10, do: %{"id" => (i - 1) * 10 + j, "name" => "row_#{j}"}
+
+          Dux.from_list(rows)
+          |> Dux.to_parquet(Path.join(input_dir, "part_#{i}.parquet"))
+        end
+
+        {:ok, w1} = start_worker_on(node1)
+        {:ok, w2} = start_worker_on(node2)
+        Process.sleep(200)
+
+        Dux.from_parquet(Path.join(input_dir, "*.parquet"))
+        |> Dux.distribute([w1, w2])
+        |> Dux.to_csv(output_dir)
+
+        output_files = Path.wildcard(Path.join(output_dir, "*.csv"))
+        assert length(output_files) == 2
+
+        # Read back all CSVs and verify total row count
+        total_rows =
+          Enum.reduce(output_files, 0, fn file, acc ->
+            acc + (Dux.from_csv(file) |> Dux.n_rows())
+          end)
+
+        assert total_rows == 40
+      after
+        :peer.stop(peer1)
+        :peer.stop(peer2)
+        File.rm_rf!(input_dir)
+        File.rm_rf!(output_dir)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Round-trip: distributed write → read
+  # ---------------------------------------------------------------------------
+
+  describe "distributed write → read round-trip" do
+    test "distributed write then distributed read produces same data" do
+      input_dir = tmp_path("dw_roundtrip_input")
+      output_dir = tmp_path("dw_roundtrip_output")
+      File.mkdir_p!(input_dir)
+      File.mkdir_p!(output_dir)
+
+      {peer1, node1} = start_peer(:dw_rt1)
+      {peer2, node2} = start_peer(:dw_rt2)
+
+      try do
+        for i <- 1..6 do
+          rows = for j <- 1..50, do: %{"x" => (i - 1) * 50 + j}
+
+          Dux.from_list(rows)
+          |> Dux.to_parquet(Path.join(input_dir, "part_#{i}.parquet"))
+        end
+
+        {:ok, w1} = start_worker_on(node1)
+        {:ok, w2} = start_worker_on(node2)
+        Process.sleep(200)
+
+        # Distributed write
+        Dux.from_parquet(Path.join(input_dir, "*.parquet"))
+        |> Dux.distribute([w1, w2])
+        |> Dux.filter_with("x <= 200")
+        |> Dux.to_parquet(output_dir)
+
+        # Distributed read of what we just wrote
+        result =
+          Dux.from_parquet(Path.join(output_dir, "*.parquet"))
+          |> Dux.distribute([w1, w2])
+          |> Dux.summarise_with(n: "COUNT(*)", total: "SUM(x)")
+          |> Dux.to_rows()
+
+        row = hd(result)
+        assert row["n"] == 200
+        assert row["total"] == div(200 * 201, 2)
+      after
+        :peer.stop(peer1)
+        :peer.stop(peer2)
+        File.rm_rf!(input_dir)
+        File.rm_rf!(output_dir)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Sad path
+  # ---------------------------------------------------------------------------
+
+  describe "sad path" do
+    test "distributed write to invalid path raises" do
+      {peer1, node1} = start_peer(:dw_sad1)
+      {peer2, node2} = start_peer(:dw_sad2)
+
+      try do
+        {:ok, w1} = start_worker_on(node1)
+        {:ok, w2} = start_worker_on(node2)
+        Process.sleep(200)
+
+        assert_raise ArgumentError, ~r/all workers failed/, fn ->
+          Dux.from_query("SELECT 1 AS x")
+          |> Dux.distribute([w1, w2])
+          |> Dux.to_parquet("/nonexistent/path/that/cannot/exist")
+        end
+      after
+        :peer.stop(peer1)
+        :peer.stop(peer2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When a pipeline has distributed workers (`Dux.distribute/2`), `to_parquet/3`, `to_csv/3`, and `to_ndjson/3` now fan out writes to workers. Each worker executes the pipeline and runs `COPY TO` locally, writing its partition to a unique file. No data funnels through the coordinator.

### How it works

```elixir
Dux.from_parquet("s3://input/**/*.parquet")
|> Dux.distribute([w1, w2])
|> Dux.filter(year == 2024)
|> Dux.to_parquet("/output/result/")
# Worker 1 writes: /output/result/part_0_12345.parquet
# Worker 2 writes: /output/result/part_1_12346.parquet
```

1. Coordinator partitions the source across workers (size-balanced)
2. Each worker gets a `%Dux{}` pipeline + output file path
3. Worker compiles pipeline to SQL, runs `COPY (query) TO 'path' (FORMAT ...)`
4. Coordinator collects results, warns on partial failure, raises on total failure

### Details

- **New `Worker.write/5`** GenServer call — builds SQL and writes locally
- **File naming**: `part_{worker_index}_{unique_id}.{ext}` prevents collisions
- **Non-empty directory warning** via Logger (cheap `File.ls` check)
- **Partial failure**: warns but succeeds if at least one worker wrote
- **Total failure**: raises `ArgumentError` with all worker error reasons

## Test plan

- [x] Parallel Parquet write across 2 peers — correct file count and data
- [x] Filter + mutate pipeline → distributed Parquet write
- [x] Parallel CSV write across 2 peers
- [x] Write → read round-trip: distributed write then distributed read
- [x] Sad path: write to invalid path raises
- [x] 596 non-distributed tests pass, Credo clean
- [x] 5 peer tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)