### PR TITLE
feat: Excel IO — from_excel/2 and to_excel/2

### DIFF
--- a/lib/dux.ex
+++ b/lib/dux.ex
@@ -267,6 +267,34 @@ defmodule Dux do
     %Dux{source: {:ndjson, path, opts}}
   end
 
+  @doc group: :io
+  @doc """
+  Read an Excel file (.xlsx) into a lazy Dux pipeline.
+
+  Uses DuckDB's `read_xlsx` function (available in DuckDB 1.5+).
+
+  ## Options
+
+    * `:sheet` — sheet name (default: first sheet)
+    * `:range` — cell range, e.g. `"A1:F1000"` (default: auto-detect)
+    * `:header` — whether the first row is a header (default: `true`)
+    * `:all_varchar` — read all columns as VARCHAR (default: `false`).
+      Useful when type inference fails on mixed-type columns.
+    * `:stop_at_empty` — stop reading at the first empty row (default: `true`)
+
+  ## Examples
+
+      df = Dux.from_excel("sales.xlsx")
+      df = Dux.from_excel("data.xlsx", sheet: "Q1 2024", range: "A1:F100")
+      df = Dux.from_excel("messy.xlsx", all_varchar: true)
+  """
+  def from_excel(path, opts \\ []) when is_binary(path) do
+    escaped = String.replace(path, "'", "''")
+    opts = Keyword.put_new(opts, :header, true)
+    read_opts = excel_read_options(opts)
+    %Dux{source: {:sql, "SELECT * FROM read_xlsx('#{escaped}'#{read_opts})"}}
+  end
+
   # ---------------------------------------------------------------------------
   # IO — writing
   # ---------------------------------------------------------------------------
@@ -342,6 +370,21 @@ defmodule Dux do
   """
   def to_ndjson(%Dux{} = dux, path, opts \\ []) when is_binary(path) do
     write_copy(dux, path, "JSON", opts)
+  end
+
+  @doc group: :io
+  @doc """
+  Write a Dux to an Excel file (.xlsx). Triggers computation.
+
+  Requires the DuckDB `excel` extension (auto-installed, needs explicit LOAD).
+
+  ## Examples
+
+      Dux.from_list([%{name: "Alice", age: 30}, %{name: "Bob", age: 25}])
+      |> Dux.to_excel("/tmp/output.xlsx")
+  """
+  def to_excel(%Dux{} = dux, path) when is_binary(path) do
+    write_copy(dux, path, "XLSX", [])
   end
 
   @doc group: :io
@@ -1836,6 +1879,9 @@ defmodule Dux do
         Dux.Backend.execute(conn, setup_sql)
       end)
 
+      # XLSX format requires explicit extension loading
+      if format == "XLSX", do: Dux.Backend.execute(conn, "INSTALL excel; LOAD excel;")
+
       copy_opts = build_copy_options(format, opts)
       escaped_path = String.replace(path, "'", "''")
       sql = "COPY (#{query_sql}) TO '#{escaped_path}' (#{copy_opts})"
@@ -1938,6 +1984,7 @@ defmodule Dux do
   defp format_extension("CSV"), do: "csv"
   defp format_extension("PARQUET"), do: "parquet"
   defp format_extension("JSON"), do: "ndjson"
+  defp format_extension("XLSX"), do: "xlsx"
 
   defp warn_if_non_empty(path) do
     require Logger
@@ -2009,6 +2056,34 @@ defmodule Dux do
 
   defp build_copy_options("JSON", _opts) do
     "FORMAT JSON"
+  end
+
+  defp build_copy_options("XLSX", _opts) do
+    "FORMAT XLSX, HEADER true"
+  end
+
+  defp excel_read_options(opts) do
+    parts =
+      [
+        excel_opt(opts, :sheet, fn s -> "sheet = '#{String.replace(to_string(s), "'", "''")}'" end),
+        excel_opt(opts, :range, fn r -> "range = '#{r}'" end),
+        excel_opt(opts, :header, fn v -> "header = #{v}" end),
+        excel_opt(opts, :all_varchar, fn
+          true -> "all_varchar = true"
+          _ -> nil
+        end),
+        excel_opt(opts, :stop_at_empty, fn v -> "stop_at_empty = #{v}" end)
+      ]
+      |> Enum.reject(&is_nil/1)
+
+    if parts == [], do: "", else: ", " <> Enum.join(parts, ", ")
+  end
+
+  defp excel_opt(opts, key, formatter) do
+    case Keyword.get(opts, key) do
+      nil -> nil
+      val -> formatter.(val)
+    end
   end
 
   defp normalize_sort(col) when is_atom(col), do: [{:asc, to_col_name(col)}]

--- a/lib/dux.ex
+++ b/lib/dux.ex
@@ -280,6 +280,12 @@ defmodule Dux do
     * `:header` — whether the first row is a header (default: `true`)
     * `:all_varchar` — read all columns as VARCHAR (default: `false`).
       Useful when type inference fails on mixed-type columns.
+    * `:ignore_errors` — replace type-cast failures with NULL instead of
+      raising (default: `true`). DuckDB infers column types from the first
+      data row only — if a column has NULL or a number in row 1 but strings
+      later, this prevents hard failures.
+    * `:empty_as_varchar` — infer empty cells as VARCHAR instead of DOUBLE
+      (default: `true`)
     * `:stop_at_empty` — stop reading at the first empty row (default: `true`)
 
   ## Examples
@@ -288,9 +294,19 @@ defmodule Dux do
       df = Dux.from_excel("data.xlsx", sheet: "Q1 2024", range: "A1:F100")
       df = Dux.from_excel("messy.xlsx", all_varchar: true)
   """
+  @excel_read_defaults [
+    sheet: nil,
+    range: nil,
+    header: true,
+    all_varchar: false,
+    ignore_errors: true,
+    empty_as_varchar: true,
+    stop_at_empty: nil
+  ]
+
   def from_excel(path, opts \\ []) when is_binary(path) do
+    opts = Keyword.validate!(opts, @excel_read_defaults)
     escaped = String.replace(path, "'", "''")
-    opts = Keyword.put_new(opts, :header, true)
     read_opts = excel_read_options(opts)
     %Dux{source: {:sql, "SELECT * FROM read_xlsx('#{escaped}'#{read_opts})"}}
   end
@@ -2070,6 +2086,14 @@ defmodule Dux do
         excel_opt(opts, :header, fn v -> "header = #{v}" end),
         excel_opt(opts, :all_varchar, fn
           true -> "all_varchar = true"
+          _ -> nil
+        end),
+        excel_opt(opts, :ignore_errors, fn
+          true -> "ignore_errors = true"
+          _ -> nil
+        end),
+        excel_opt(opts, :empty_as_varchar, fn
+          true -> "empty_as_varchar = true"
           _ -> nil
         end),
         excel_opt(opts, :stop_at_empty, fn v -> "stop_at_empty = #{v}" end)

--- a/test/dux/excel_test.exs
+++ b/test/dux/excel_test.exs
@@ -1,0 +1,271 @@
+defmodule Dux.ExcelTest do
+  use ExUnit.Case, async: false
+
+  @tmp_dir System.tmp_dir!()
+
+  defp tmp_path(name) do
+    Path.join(@tmp_dir, "dux_excel_#{System.unique_integer([:positive])}_#{name}")
+  end
+
+  # Helper to create a test xlsx file via DuckDB
+  defp write_xlsx(path, sql) do
+    conn = Dux.Connection.get_conn()
+    Adbc.Connection.query!(conn, "INSTALL excel; LOAD excel;")
+    escaped = String.replace(path, "'", "''")
+    Adbc.Connection.query!(conn, "COPY (#{sql}) TO '#{escaped}' (FORMAT XLSX, HEADER true)")
+  end
+
+  # ---------------------------------------------------------------------------
+  # Happy path — reading
+  # ---------------------------------------------------------------------------
+
+  describe "from_excel" do
+    test "reads basic xlsx file" do
+      path = tmp_path("basic.xlsx")
+
+      try do
+        write_xlsx(path, "SELECT 1 AS id, 'Alice' AS name UNION ALL SELECT 2, 'Bob'")
+
+        result =
+          Dux.from_excel(path)
+          |> Dux.sort_by(:id)
+          |> Dux.to_rows()
+
+        assert length(result) == 2
+        assert hd(result)["name"] == "Alice"
+      after
+        File.rm(path)
+      end
+    end
+
+    test "reads with all_varchar option" do
+      path = tmp_path("varchar.xlsx")
+
+      try do
+        write_xlsx(path, "SELECT 42 AS val, 'text' AS label")
+
+        result =
+          Dux.from_excel(path, all_varchar: true)
+          |> Dux.to_rows()
+
+        row = hd(result)
+        # With all_varchar, numeric values come back as strings
+        assert is_binary(row["val"])
+      after
+        File.rm(path)
+      end
+    end
+
+    test "pipelines normally after read" do
+      require Dux
+      path = tmp_path("pipeline.xlsx")
+
+      try do
+        write_xlsx(
+          path,
+          "SELECT * FROM (VALUES (1, 'US'), (2, 'EU'), (3, 'US'), (4, 'APAC'), (5, 'EU')) t(id, region)"
+        )
+
+        result =
+          Dux.from_excel(path)
+          |> Dux.filter(region == "US")
+          |> Dux.to_columns()
+
+        assert result["id"] == [1, 3]
+      after
+        File.rm(path)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Happy path — writing
+  # ---------------------------------------------------------------------------
+
+  describe "to_excel" do
+    test "writes basic xlsx file" do
+      path = tmp_path("write_basic.xlsx")
+
+      try do
+        Dux.from_list([%{"x" => 1, "y" => "hello"}, %{"x" => 2, "y" => "world"}])
+        |> Dux.to_excel(path)
+
+        assert File.exists?(path)
+        assert File.stat!(path).size > 0
+      after
+        File.rm(path)
+      end
+    end
+
+    test "round-trip: write then read" do
+      path = tmp_path("roundtrip.xlsx")
+
+      try do
+        Dux.from_list([
+          %{"id" => 1, "name" => "Alice", "score" => 95.5},
+          %{"id" => 2, "name" => "Bob", "score" => 87.0},
+          %{"id" => 3, "name" => "Carol", "score" => 92.3}
+        ])
+        |> Dux.to_excel(path)
+
+        result =
+          Dux.from_excel(path)
+          |> Dux.sort_by(:id)
+          |> Dux.to_rows()
+
+        assert length(result) == 3
+        assert hd(result)["name"] == "Alice"
+        assert_in_delta hd(result)["score"], 95.5, 0.1
+      after
+        File.rm(path)
+      end
+    end
+
+    test "write with pipeline before" do
+      require Dux
+      path = tmp_path("pipeline_write.xlsx")
+
+      try do
+        Dux.from_query("SELECT * FROM range(1, 11) t(x)")
+        |> Dux.filter(x > 5)
+        |> Dux.mutate(doubled: x * 2)
+        |> Dux.to_excel(path)
+
+        result =
+          Dux.from_excel(path)
+          |> Dux.sort_by(:x)
+          |> Dux.to_columns()
+
+        assert result["x"] == [6, 7, 8, 9, 10]
+        assert result["doubled"] == [12, 14, 16, 18, 20]
+      after
+        File.rm(path)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Sad path
+  # ---------------------------------------------------------------------------
+
+  describe "sad path" do
+    test "from_excel with non-existent file raises on compute" do
+      assert_raise ArgumentError, ~r/DuckDB query failed/, fn ->
+        Dux.from_excel("/nonexistent/path/file.xlsx")
+        |> Dux.compute()
+      end
+    end
+
+    test "to_excel with invalid path raises" do
+      assert_raise ArgumentError, ~r/DuckDB write failed/, fn ->
+        Dux.from_list([%{"x" => 1}])
+        |> Dux.to_excel("/nonexistent/dir/file.xlsx")
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Adversarial
+  # ---------------------------------------------------------------------------
+
+  describe "adversarial" do
+    test "round-trip preserves special characters" do
+      path = tmp_path("special_chars.xlsx")
+
+      try do
+        Dux.from_list([
+          %{"text" => "it's a test"},
+          %{"text" => "has \"quotes\""},
+          %{"text" => "line1\nline2"}
+        ])
+        |> Dux.to_excel(path)
+
+        result = Dux.from_excel(path) |> Dux.to_columns()
+        assert "it's a test" in result["text"]
+      after
+        File.rm(path)
+      end
+    end
+
+    test "round-trip preserves nulls" do
+      path = tmp_path("nulls.xlsx")
+
+      try do
+        # Put non-null string first so type inference gets VARCHAR, not DOUBLE
+        Dux.from_query("SELECT 1 AS id, 'Alice' AS name UNION ALL SELECT 2, NULL")
+        |> Dux.to_excel(path)
+
+        result =
+          Dux.from_excel(path)
+          |> Dux.sort_by(:id)
+          |> Dux.to_rows()
+
+        assert length(result) == 2
+        assert hd(result)["name"] == "Alice"
+        # NULL may come back as nil or empty string depending on Excel handling
+        second_name = Enum.at(result, 1)["name"]
+        assert second_name == nil or second_name == ""
+      after
+        File.rm(path)
+      end
+    end
+
+    test "empty dataframe writes valid xlsx" do
+      path = tmp_path("empty.xlsx")
+
+      try do
+        Dux.from_query("SELECT 1 AS x WHERE false")
+        |> Dux.to_excel(path)
+
+        assert File.exists?(path)
+      after
+        File.rm(path)
+      end
+    end
+
+    test "many columns" do
+      path = tmp_path("wide.xlsx")
+
+      try do
+        # 50 columns
+        cols = for i <- 1..50, into: %{}, do: {"col_#{i}", i}
+
+        Dux.from_list([cols])
+        |> Dux.to_excel(path)
+
+        result = Dux.from_excel(path) |> Dux.to_rows()
+        assert length(result) == 1
+        assert hd(result)["col_1"] == 1
+        assert hd(result)["col_50"] == 50
+      after
+        File.rm(path)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Scale
+  # ---------------------------------------------------------------------------
+
+  describe "scale" do
+    test "round-trip 1000 rows" do
+      path = tmp_path("scale.xlsx")
+
+      try do
+        Dux.from_query("SELECT x, x * 2 AS doubled FROM range(1, 1001) t(x)")
+        |> Dux.to_excel(path)
+
+        result =
+          Dux.from_excel(path)
+          |> Dux.summarise_with(n: "COUNT(*)", total: "SUM(x)")
+          |> Dux.to_rows()
+
+        row = hd(result)
+        assert row["n"] == 1000
+        assert row["total"] == div(1000 * 1001, 2)
+      after
+        File.rm(path)
+      end
+    end
+  end
+end

--- a/test/dux/excel_test.exs
+++ b/test/dux/excel_test.exs
@@ -187,12 +187,14 @@ defmodule Dux.ExcelTest do
       end
     end
 
-    test "round-trip preserves nulls" do
+    test "round-trip with null in first row survives via ignore_errors" do
       path = tmp_path("nulls.xlsx")
 
       try do
-        # Put non-null string first so type inference gets VARCHAR, not DOUBLE
-        Dux.from_query("SELECT 1 AS id, 'Alice' AS name UNION ALL SELECT 2, NULL")
+        # NULL in the first data row causes DuckDB to infer name as DOUBLE.
+        # With ignore_errors: true (default), 'Bob' fails to cast to DOUBLE
+        # and becomes NULL — but the read doesn't crash.
+        Dux.from_query("SELECT 1 AS id, NULL AS name UNION ALL SELECT 2, 'Bob'")
         |> Dux.to_excel(path)
 
         result =
@@ -200,11 +202,46 @@ defmodule Dux.ExcelTest do
           |> Dux.sort_by(:id)
           |> Dux.to_rows()
 
+        # Both rows read — 'Bob' may be NULL due to type mismatch
         assert length(result) == 2
-        assert hd(result)["name"] == "Alice"
-        # NULL may come back as nil or empty string depending on Excel handling
-        second_name = Enum.at(result, 1)["name"]
-        assert second_name == nil or second_name == ""
+      after
+        File.rm(path)
+      end
+    end
+
+    test "null in first row with all_varchar preserves all data" do
+      path = tmp_path("nulls_varchar.xlsx")
+
+      try do
+        Dux.from_query("SELECT 1 AS id, NULL AS name UNION ALL SELECT 2, 'Bob'")
+        |> Dux.to_excel(path)
+
+        # all_varchar bypasses type inference entirely
+        result =
+          Dux.from_excel(path, all_varchar: true)
+          |> Dux.sort_by(:id)
+          |> Dux.to_rows()
+
+        assert length(result) == 2
+        assert Enum.at(result, 1)["name"] == "Bob"
+      after
+        File.rm(path)
+      end
+    end
+
+    test "ignore_errors: false + empty_as_varchar: false raises on type mismatch" do
+      path = tmp_path("nulls_strict.xlsx")
+
+      try do
+        Dux.from_query("SELECT 1 AS id, NULL AS name UNION ALL SELECT 2, 'Bob'")
+        |> Dux.to_excel(path)
+
+        # With both safety nets off, DuckDB infers NULL cell as DOUBLE
+        # and fails to parse 'Bob' as DOUBLE
+        assert_raise ArgumentError, ~r/DuckDB query failed/, fn ->
+          Dux.from_excel(path, ignore_errors: false, empty_as_varchar: false)
+          |> Dux.to_rows()
+        end
       after
         File.rm(path)
       end


### PR DESCRIPTION
## Summary

Add Excel (.xlsx) read and write support via DuckDB's `read_xlsx` and `COPY TO XLSX`.

### Usage

```elixir
# Read
df = Dux.from_excel("sales.xlsx")
df = Dux.from_excel("data.xlsx", sheet: "Q1 2024", range: "A1:F100")
df = Dux.from_excel("messy.xlsx", all_varchar: true)

# Write
Dux.from_list([%{name: "Alice", age: 30}])
|> Dux.to_excel("/tmp/output.xlsx")
```

### Safe defaults for messy spreadsheets

DuckDB infers Excel column types from the first data row only. A NULL or empty cell in row 1 causes the column to be inferred as DOUBLE, which fails when later rows contain strings. Two safety nets enabled by default:

- **`ignore_errors: true`** — type-cast failures become NULL instead of raising
- **`empty_as_varchar: true`** — empty/null cells infer as VARCHAR instead of DOUBLE

Together these handle the most common "messy spreadsheet" scenarios. Users who want strict type checking can pass `ignore_errors: false, empty_as_varchar: false`. Users who want full control use `all_varchar: true`.

Uses `Keyword.validate!` for option checking — typos like `headers:` instead of `header:` raise immediately.

## Test plan

**Happy path (3):**
- [x] Read basic xlsx with column names
- [x] Read with `all_varchar: true`
- [x] Read → filter pipeline composition

**Happy path — writing (3):**
- [x] Write basic xlsx
- [x] Write → read round-trip with types
- [x] Pipeline before write

**Sad path (2):**
- [x] Non-existent file raises
- [x] Invalid write path raises

**Adversarial (5):**
- [x] Special characters survive round-trip
- [x] NULL in first row handled by `ignore_errors` (no crash)
- [x] NULL in first row + `all_varchar: true` preserves all data
- [x] `ignore_errors: false` + `empty_as_varchar: false` raises on type mismatch
- [x] Empty dataframe writes valid xlsx
- [x] 50-column wide table round-trip

**Scale (1):**
- [x] 1000-row round-trip with SUM verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)