### PR TITLE
Remove Dux.Flame.start_pool/1, document FLAME setup

### DIFF
--- a/guides/distributed.md
+++ b/guides/distributed.md
@@ -81,18 +81,84 @@ workers = Dux.Remote.Worker.list()
 
 ### FLAME: Elastic Cloud Workers
 
-With [FLAME](https://github.com/phoenixframework/flame), spin up ephemeral
-cloud machines with DuckDB on demand:
+[FLAME](https://github.com/phoenixframework/flame) boots ephemeral cloud
+machines with a full copy of your application. Combined with Dux, each runner
+gets its own DuckDB, reads S3 data directly, and auto-terminates when idle.
+
+#### Livebook on Fly.io
 
 ```elixir
-Dux.Flame.start_pool(
-  backend: {FLAME.FlyBackend, token: "...", cpus: 4, memory_mb: 16_384},
-  max: 10
+# 1. Start a FLAME pool
+Kino.start_child!(
+  {FLAME.Pool,
+    name: :dux_pool,
+    code_sync: [
+      start_apps: true,
+      sync_beams: [Path.join(System.tmp_dir!(), "livebook_runtime")]
+    ],
+    min: 0,
+    max: 10,
+    backend: {FLAME.FlyBackend,
+      cpu_kind: "performance", cpus: 4, memory_mb: 8192,
+      token: System.fetch_env!("FLY_API_TOKEN"),
+      env: Map.take(System.get_env(), ["LIVEBOOK_COOKIE"])
+    },
+    idle_shutdown_after: :timer.minutes(5)}
 )
 
-workers = Dux.Flame.spin_up(5)
-# 5 cloud machines with DuckDB, auto-terminate after idle timeout
+# 2. Spin up workers
+workers = Dux.Flame.spin_up(5, pool: :dux_pool)
 ```
+
+Key Livebook-specific settings:
+
+- **`Kino.start_child!/1`** — supervises the pool under Livebook's runtime
+- **`sync_beams`** — syncs notebook-compiled beam files to runners
+- **`start_apps: true`** — starts all applications (including `:dux`) on runners
+- **`LIVEBOOK_COOKIE`** — required for BEAM distribution between nodes
+
+#### Deployed Elixir app
+
+Add the FLAME pool to your application supervision tree:
+
+```elixir
+# In your application.ex children:
+children = [
+  {FLAME.Pool,
+    name: :dux_pool,
+    backend: {FLAME.FlyBackend,
+      token: System.fetch_env!("FLY_API_TOKEN"),
+      cpus: 4, memory_mb: 16_384},
+    max: 10,
+    code_sync: [start_apps: [:dux], copy_apps: true],
+    idle_shutdown_after: :timer.minutes(5)}
+]
+```
+
+Then at runtime:
+
+```elixir
+workers = Dux.Flame.spin_up(5, pool: :dux_pool)
+```
+
+#### Using FLAME workers
+
+Once spun up, FLAME workers are just worker PIDs — `distribute/2` doesn't
+know or care whether they're FLAME runners or static cluster nodes:
+
+```elixir
+workers = Dux.Flame.spin_up(5, pool: :dux_pool)
+
+Dux.from_parquet("s3://lake/events/**/*.parquet")
+|> Dux.distribute(workers)
+|> Dux.filter(amount > 100)
+|> Dux.group_by(:region)
+|> Dux.summarise(total: sum(amount))
+|> Dux.compute()
+```
+
+Workers read S3 directly — no data flows through your machine. After the
+idle timeout, FLAME terminates the runners automatically.
 
 ## Query Decomposition
 

--- a/lib/dux/flame.ex
+++ b/lib/dux/flame.ex
@@ -1,29 +1,35 @@
 if Code.ensure_loaded?(FLAME) do
   defmodule Dux.Flame do
     @moduledoc """
-    Elastic compute via FLAME for distributed Dux queries.
+    Spin up Dux workers on FLAME runners for distributed queries.
 
-    FLAME boots ephemeral cloud machines with a full copy of your application,
-    starts `Dux.Remote.Worker` on each, and auto-terminates when idle. No Docker
-    builds, no cluster management.
+    FLAME handles pool management and machine lifecycle — see the
+    [FLAME docs](https://hexdocs.pm/flame) for pool configuration.
+    This module provides `spin_up/2` to place `Dux.Remote.Worker`
+    processes on FLAME runners, and `status/1` to inspect the cluster.
 
-    ## Quick start
+    ## Livebook
 
-    Works in both Livebook and deployed Elixir apps — `start_pool/1`
-    auto-detects the environment and configures `code_sync` and supervision
-    accordingly.
-
-        # Start a FLAME pool
-        Dux.Flame.start_pool(
-          backend: {FLAME.FlyBackend,
-            token: System.fetch_env!("FLY_API_TOKEN"),
-            cpus: 4,
-            memory_mb: 16_384},
-          max: 10
+        # 1. Start a FLAME pool (see FLAME docs for backend options)
+        Kino.start_child!(
+          {FLAME.Pool,
+            name: :dux_pool,
+            code_sync: [
+              start_apps: true,
+              sync_beams: [Path.join(System.tmp_dir!(), "livebook_runtime")]
+            ],
+            min: 0,
+            max: 10,
+            backend: {FLAME.FlyBackend,
+              cpu_kind: "performance", cpus: 4, memory_mb: 8192,
+              token: System.fetch_env!("FLY_API_TOKEN"),
+              env: Map.take(System.get_env(), ["LIVEBOOK_COOKIE"])
+            },
+            idle_shutdown_after: :timer.minutes(5)}
         )
 
-        # Spin up workers and distribute
-        workers = Dux.Flame.spin_up(5)
+        # 2. Spin up workers and distribute
+        workers = Dux.Flame.spin_up(5, pool: :dux_pool)
 
         Dux.from_parquet("s3://bucket/data/**/*.parquet")
         |> Dux.distribute(workers)
@@ -32,110 +38,24 @@ if Code.ensure_loaded?(FLAME) do
         |> Dux.summarise(total: sum(amount))
         |> Dux.compute()
 
+    ## Deployed app
+
+        # In your application supervisor children:
+        {FLAME.Pool,
+          name: :dux_pool,
+          backend: {FLAME.FlyBackend, ...},
+          max: 10,
+          code_sync: [start_apps: [:dux], copy_apps: true],
+          idle_shutdown_after: :timer.minutes(5)}
+
+        # Then at runtime:
+        workers = Dux.Flame.spin_up(5, pool: :dux_pool)
+
     Workers read S3 data directly — nothing flows through your machine.
-    After 5 minutes idle (configurable), machines auto-terminate.
-
-    ## Pools
-
-    You can run multiple pools for different workloads:
-
-        Dux.Flame.start_pool(name: Dux.CpuPool, backend: cpu_backend, max: 10)
-        Dux.Flame.start_pool(name: Dux.GpuPool, backend: gpu_backend, max: 4)
-
-        cpu_workers = Dux.Flame.spin_up(5, pool: Dux.CpuPool)
-        gpu_workers = Dux.Flame.spin_up(2, pool: Dux.GpuPool)
+    After idle timeout, FLAME auto-terminates the runners.
     """
 
     @default_pool Dux.FlamePool
-
-    @doc """
-    Start a FLAME pool for Dux workers.
-
-    Automatically detects whether it's running inside Livebook and adjusts
-    the supervisor strategy and `code_sync` configuration accordingly.
-
-    ## Options
-
-      * `:name` — pool name (default: `Dux.FlamePool`)
-      * `:backend` — FLAME backend (required). E.g. `{FLAME.FlyBackend, token: ..., cpus: 4}`
-      * `:max` — maximum number of runners (default: 10)
-      * `:min` — minimum runners to keep warm (default: 0)
-      * `:idle_shutdown_after` — ms before idle runner terminates (default: 5 minutes)
-      * `:boot_timeout` — ms to wait for runner boot (default: 30 seconds)
-      * `:env` — environment variables to pass to runners (auto-includes `LIVEBOOK_COOKIE` in Livebook)
-
-    Returns `{:ok, pid}` of the pool supervisor.
-
-    ## Livebook
-
-        Dux.Flame.start_pool(
-          backend: {FLAME.FlyBackend,
-            token: System.fetch_env!("FLY_API_TOKEN"),
-            cpus: 4, memory_mb: 16_384},
-          max: 10
-        )
-
-    ## Deployed app
-
-        Dux.Flame.start_pool(
-          backend: {FLAME.FlyBackend,
-            token: System.fetch_env!("FLY_API_TOKEN"),
-            cpus: 4, memory_mb: 16_384},
-          max: 10
-        )
-    """
-    def start_pool(opts \\ []) do
-      backend = Keyword.fetch!(opts, :backend)
-      livebook? = Code.ensure_loaded?(Kino)
-
-      code_sync =
-        cond do
-          is_atom(backend) and backend == FLAME.LocalBackend ->
-            []
-
-          livebook? ->
-            [
-              code_sync: [
-                start_apps: true,
-                sync_beams: [Path.join(System.tmp_dir!(), "livebook_runtime")]
-              ]
-            ]
-
-          true ->
-            [code_sync: [start_apps: [:dux], copy_apps: true]]
-        end
-
-      # In Livebook, inject LIVEBOOK_COOKIE into runner env for node connectivity
-      backend =
-        if livebook? and is_tuple(backend) do
-          {mod, backend_opts} = backend
-          env = Keyword.get(backend_opts, :env, %{})
-          env = Map.merge(Map.take(System.get_env(), ["LIVEBOOK_COOKIE"]), env)
-          {mod, Keyword.put(backend_opts, :env, env)}
-        else
-          backend
-        end
-
-      pool_opts =
-        [
-          name: Keyword.get(opts, :name, @default_pool),
-          max: Keyword.get(opts, :max, 10),
-          min: Keyword.get(opts, :min, 0),
-          max_concurrency: 1,
-          idle_shutdown_after: Keyword.get(opts, :idle_shutdown_after, :timer.minutes(5)),
-          boot_timeout: Keyword.get(opts, :boot_timeout, 30_000),
-          backend: backend
-        ] ++ code_sync
-
-      if livebook? do
-        apply(Kino, :start_child!, [{FLAME.Pool, pool_opts}])
-      else
-        DynamicSupervisor.start_child(
-          Dux.DynamicSupervisor,
-          {FLAME.Pool, pool_opts}
-        )
-      end
-    end
 
     @doc """
     Spin up `n` Dux workers on FLAME runners.

--- a/lib/dux/flame.ex
+++ b/lib/dux/flame.ex
@@ -9,7 +9,11 @@ if Code.ensure_loaded?(FLAME) do
 
     ## Quick start
 
-        # Start a FLAME pool (e.g. in Livebook)
+    Works in both Livebook and deployed Elixir apps — `start_pool/1`
+    auto-detects the environment and configures `code_sync` and supervision
+    accordingly.
+
+        # Start a FLAME pool
         Dux.Flame.start_pool(
           backend: {FLAME.FlyBackend,
             token: System.fetch_env!("FLY_API_TOKEN"),
@@ -19,12 +23,14 @@ if Code.ensure_loaded?(FLAME) do
         )
 
         # Spin up workers and distribute
+        workers = Dux.Flame.spin_up(5)
+
         Dux.from_parquet("s3://bucket/data/**/*.parquet")
-        |> Dux.distribute(Dux.Flame.spin_up(5))
+        |> Dux.distribute(workers)
         |> Dux.filter(amount > 100)
         |> Dux.group_by(:region)
         |> Dux.summarise(total: sum(amount))
-        |> Dux.to_rows()
+        |> Dux.compute()
 
     Workers read S3 data directly — nothing flows through your machine.
     After 5 minutes idle (configurable), machines auto-terminate.
@@ -45,6 +51,9 @@ if Code.ensure_loaded?(FLAME) do
     @doc """
     Start a FLAME pool for Dux workers.
 
+    Automatically detects whether it's running inside Livebook and adjusts
+    the supervisor strategy and `code_sync` configuration accordingly.
+
     ## Options
 
       * `:name` — pool name (default: `Dux.FlamePool`)
@@ -53,11 +62,59 @@ if Code.ensure_loaded?(FLAME) do
       * `:min` — minimum runners to keep warm (default: 0)
       * `:idle_shutdown_after` — ms before idle runner terminates (default: 5 minutes)
       * `:boot_timeout` — ms to wait for runner boot (default: 30 seconds)
+      * `:env` — environment variables to pass to runners (auto-includes `LIVEBOOK_COOKIE` in Livebook)
 
     Returns `{:ok, pid}` of the pool supervisor.
+
+    ## Livebook
+
+        Dux.Flame.start_pool(
+          backend: {FLAME.FlyBackend,
+            token: System.fetch_env!("FLY_API_TOKEN"),
+            cpus: 4, memory_mb: 16_384},
+          max: 10
+        )
+
+    ## Deployed app
+
+        Dux.Flame.start_pool(
+          backend: {FLAME.FlyBackend,
+            token: System.fetch_env!("FLY_API_TOKEN"),
+            cpus: 4, memory_mb: 16_384},
+          max: 10
+        )
     """
     def start_pool(opts \\ []) do
       backend = Keyword.fetch!(opts, :backend)
+      livebook? = Code.ensure_loaded?(Kino)
+
+      code_sync =
+        cond do
+          is_atom(backend) and backend == FLAME.LocalBackend ->
+            []
+
+          livebook? ->
+            [
+              code_sync: [
+                start_apps: true,
+                sync_beams: [Path.join(System.tmp_dir!(), "livebook_runtime")]
+              ]
+            ]
+
+          true ->
+            [code_sync: [start_apps: [:dux], copy_apps: true]]
+        end
+
+      # In Livebook, inject LIVEBOOK_COOKIE into runner env for node connectivity
+      backend =
+        if livebook? and is_tuple(backend) do
+          {mod, backend_opts} = backend
+          env = Keyword.get(backend_opts, :env, %{})
+          env = Map.merge(Map.take(System.get_env(), ["LIVEBOOK_COOKIE"]), env)
+          {mod, Keyword.put(backend_opts, :env, env)}
+        else
+          backend
+        end
 
       pool_opts =
         [
@@ -68,16 +125,16 @@ if Code.ensure_loaded?(FLAME) do
           idle_shutdown_after: Keyword.get(opts, :idle_shutdown_after, :timer.minutes(5)),
           boot_timeout: Keyword.get(opts, :boot_timeout, 30_000),
           backend: backend
-        ] ++
-          if(backend != FLAME.LocalBackend,
-            do: [code_sync: [start_apps: [:dux], copy_apps: true]],
-            else: []
-          )
+        ] ++ code_sync
 
-      DynamicSupervisor.start_child(
-        Dux.DynamicSupervisor,
-        {FLAME.Pool, pool_opts}
-      )
+      if livebook? do
+        apply(Kino, :start_child!, [{FLAME.Pool, pool_opts}])
+      else
+        DynamicSupervisor.start_child(
+          Dux.DynamicSupervisor,
+          {FLAME.Pool, pool_opts}
+        )
+      end
     end
 
     @doc """

--- a/test/dux/flame_test.exs
+++ b/test/dux/flame_test.exs
@@ -10,13 +10,15 @@ if Code.ensure_loaded?(FLAME) do
       pool_name = :"flame_test_#{System.unique_integer([:positive])}"
 
       {:ok, _} =
-        Dux.Flame.start_pool(
-          name: pool_name,
-          backend: FLAME.LocalBackend,
-          min: 0,
-          max: 5,
-          idle_shutdown_after: :timer.seconds(30),
-          boot_timeout: 30_000
+        DynamicSupervisor.start_child(
+          Dux.DynamicSupervisor,
+          {FLAME.Pool,
+           name: pool_name,
+           backend: FLAME.LocalBackend,
+           min: 0,
+           max: 5,
+           idle_shutdown_after: :timer.seconds(30),
+           boot_timeout: 30_000}
         )
 
       %{pool: pool_name}


### PR DESCRIPTION
## Summary

- Remove `Dux.Flame.start_pool/1` — pool config is tightly coupled to execution context (Livebook needs `Kino.start_child!`, `sync_beams`, `LIVEBOOK_COOKIE`; deployed apps need `DynamicSupervisor`, `copy_apps`). Users configure FLAME pools directly.
- Keep `Dux.Flame.spin_up/2` and `status/1` — thin, useful wrappers
- Update `Dux.Flame` moduledoc with copy-paste examples for Livebook and deployed apps
- Expand FLAME section in distributed execution guide with full setup for both contexts

## Test plan

- [x] Compiles with `--warnings-as-errors`
- [x] Credo strict passes
- [ ] Livebook: manual test with `Kino.start_child!` + `Dux.Flame.spin_up/2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)