### PR TITLE
Fix asof_join doc group typo

### DIFF
--- a/lib/dux.ex
+++ b/lib/dux.ex
@@ -1218,7 +1218,7 @@ defmodule Dux do
     %{left | ops: ops ++ [{:join, right, how, on_cols, suffix}]}
   end
 
-  @doc group: :join
+  @doc group: :joins
   @doc """
   ASOF join — match each left row to the nearest right row satisfying an inequality.
 


### PR DESCRIPTION
## Summary

`asof_join/3` had `@doc group: :join` (singular) instead of `:joins`, putting it in its own section on hexdocs instead of with the other joins.

One-character fix: `:join` → `:joins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)