### PR TITLE
Add cond/if/in to Query macro, document function pass-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,21 @@ min_amount = 500
 Dux.filter(df, amount > ^min_amount and status == "active")
 ```
 
-The `_with` variants accept raw DuckDB SQL for anything the macro doesn't cover:
+All DuckDB functions work inside expressions — `year()`, `lower()`, `coalesce()`, `regexp_matches()`, and [hundreds more](https://duckdb.org/docs/sql/functions/overview). `cond` maps to `CASE WHEN`, `in` maps to `IN`:
+
+```elixir
+Dux.mutate(df,
+  tier: cond do
+    amount > 1000 -> "gold"
+    amount > 100 -> "silver"
+    true -> "bronze"
+  end
+)
+
+Dux.filter(df, status in ["active", "pending"])
+```
+
+The `_with` variants accept raw DuckDB SQL for window functions and other constructs the macro doesn't cover:
 
 ```elixir
 Dux.mutate_with(df, rank: "ROW_NUMBER() OVER (PARTITION BY dept ORDER BY salary DESC)")

--- a/guides/getting-started.livemd
+++ b/guides/getting-started.livemd
@@ -35,9 +35,18 @@ penguins
 
 ## Materialization
 
-Pipelines are lazy — nothing executes until you materialise. `compute/1`
-executes and returns a `%Dux{}` with the data. `to_rows/1` and `to_columns/1`
-extract raw Elixir data structures:
+Pipelines are lazy — nothing executes until you materialise:
+
+- `compute/1` — execute and return a `%Dux{}` with the data
+- `to_rows/1` — execute and return a list of maps
+- `to_columns/1` — execute and return a map of lists
+
+```elixir
+penguins
+|> Dux.filter(species == "Adelie")
+|> Dux.head(3)
+|> Dux.compute()
+```
 
 ```elixir
 penguins
@@ -112,6 +121,106 @@ penguins
 |> Dux.sort_by(desc: :n)
 |> Dux.compute()
 ```
+
+## Conditional Expressions
+
+Elixir's `cond` compiles to SQL `CASE WHEN` — classify rows directly in your pipeline:
+
+```elixir
+penguins
+|> Dux.drop_nil([:body_mass_g])
+|> Dux.mutate(
+  size: cond do
+    body_mass_g > 5000 -> "large"
+    body_mass_g > 3500 -> "medium"
+    true -> "small"
+  end
+)
+|> Dux.group_by(:size)
+|> Dux.summarise(n: count(species))
+|> Dux.compute()
+```
+
+For simple two-branch logic, use `if/else`:
+
+```elixir
+penguins
+|> Dux.drop_nil([:body_mass_g])
+|> Dux.mutate(heavy: if(body_mass_g > 4500, do: "yes", else: "no"))
+|> Dux.group_by(:heavy)
+|> Dux.summarise(n: count(species))
+|> Dux.compute()
+```
+
+## Membership Tests
+
+Use `in` to filter by a set of values:
+
+```elixir
+penguins
+|> Dux.filter(species in ["Adelie", "Chinstrap"])
+|> Dux.group_by(:species)
+|> Dux.summarise(n: count(species))
+|> Dux.compute()
+```
+
+Works with interpolated lists too:
+
+```elixir
+target_islands = ["Biscoe", "Dream"]
+
+penguins
+|> Dux.filter(island in ^target_islands)
+|> Dux.group_by(:island)
+|> Dux.summarise(n: count(species))
+|> Dux.compute()
+```
+
+## Using DuckDB Functions
+
+All DuckDB functions work inside the query macro — they pass through as SQL
+function calls. Here are some useful ones:
+
+```elixir
+# String functions
+penguins
+|> Dux.mutate(
+  species_lower: lower(species),
+  first_char: left(species, 1)
+)
+|> Dux.select([:species, :species_lower, :first_char])
+|> Dux.distinct()
+|> Dux.compute()
+```
+
+```elixir
+# Math and rounding
+penguins
+|> Dux.drop_nil([:bill_length_mm, :bill_depth_mm])
+|> Dux.mutate(
+  bill_ratio: round(bill_length_mm / bill_depth_mm, 2),
+  log_mass: round(ln(body_mass_g), 2)
+)
+|> Dux.select([:species, :bill_ratio, :log_mass])
+|> Dux.head(5)
+|> Dux.compute()
+```
+
+```elixir
+# Null handling with coalesce
+penguins
+|> Dux.mutate(safe_sex: coalesce(sex, "unknown"))
+|> Dux.group_by(:safe_sex)
+|> Dux.summarise(n: count(species))
+|> Dux.compute()
+```
+
+> #### Any DuckDB function works {: .info}
+>
+> `lower()`, `upper()`, `trim()`, `year()`, `month()`, `date_diff()`,
+> `regexp_matches()`, `list_extract()`, `struct_extract()`, `coalesce()`,
+> `cast()`, and [hundreds more](https://duckdb.org/docs/sql/functions/overview).
+> If DuckDB has it, you can call it in a Dux expression.
 
 ## See the SQL
 

--- a/lib/dux/query.ex
+++ b/lib/dux/query.ex
@@ -8,42 +8,122 @@ defmodule Dux.Query do
   Use `^` to interpolate Elixir variables — these become parameter bindings
   in the generated SQL, preventing SQL injection by construction.
 
-  ## Supported in queries
-
   Queries are used in `Dux.filter/2`, `Dux.mutate/2`, `Dux.summarise/2`,
   and `Dux.sort_by/2`.
 
   ## Operators
 
-  Comparison: `==`, `!=`, `>`, `>=`, `<`, `<=`
-  Arithmetic: `+`, `-`, `*`, `/`
-  Logical: `and`, `or`, `not`
-  String: `<>` (concatenation)
+  | Elixir | SQL |
+  |--------|-----|
+  | `==`, `!=`, `>`, `>=`, `<`, `<=` | `=`, `!=`, `>`, `>=`, `<`, `<=` |
+  | `+`, `-`, `*`, `/` | `+`, `-`, `*`, `/` |
+  | `and`, `or`, `not` | `AND`, `OR`, `NOT` |
+  | `<>` | `\|\|` (string concatenation) |
+  | `in [...]` | `IN (...)` |
 
-  ## Aggregation functions
+  ## Conditional expressions
 
-  `sum(col)`, `mean(col)`, `min(col)`, `max(col)`, `count(col)`,
-  `count_distinct(col)`, `avg(col)`, `std(col)`, `variance(col)`
+  Elixir's `cond` maps to SQL `CASE WHEN`:
 
-  ## Other functions
+      Dux.mutate(df,
+        tier: cond do
+          amount > 1000 -> "gold"
+          amount > 100 -> "silver"
+          true -> "bronze"
+        end
+      )
 
-  `col("name")` for columns with unusual names.
-  `cast(expr, type)` for type casting.
+  Elixir's `if/else` for simple two-branch conditionals:
+
+      Dux.mutate(df, label: if(amount > 0, do: "positive", else: "negative"))
+
+  ## Membership test
+
+  Elixir's `in` works with literal and pinned lists:
+
+      Dux.filter(df, status in ["active", "pending"])
+
+      allowed = ["active", "pending"]
+      Dux.filter(df, status in ^allowed)
 
   ## Interpolation
 
-  Use `^` to access variables defined outside the query:
+  Use `^` to interpolate Elixir values as parameter bindings:
 
       min_val = 10
       Dux.filter(df, x > ^min_val)
+
+  ## Aggregation functions
+
+  `sum`, `avg`/`mean`, `min`, `max`, `count`, `count_distinct`, `std`, `variance`
+
+  ## DuckDB functions
+
+  **All DuckDB functions work in queries.** Function calls pass through
+  to DuckDB unchanged. A few examples by category:
+
+  **Date/time:**
+
+      Dux.mutate(df, y: year(d), m: month(d), trunc: date_trunc("month", d))
+      Dux.mutate(df, age_days: date_diff("day", created_at, current_date()))
+
+  **String:**
+
+      Dux.mutate(df, low: lower(name), parts: string_split(path, "/"))
+      Dux.filter(df, starts_with(name, "A"))
+      Dux.mutate(df, clean: trim(replace(name, "  ", " ")))
+
+  **Regex:**
+
+      Dux.filter(df, regexp_matches(email, ".*@gmail\\\\.com"))
+      Dux.mutate(df, domain: regexp_extract(email, "@(.+)", 1))
+
+  **List/Array:**
+
+      Dux.mutate(df, first: list_extract(tags, 1), n: len(tags))
+
+  **Struct:**
+
+      Dux.mutate(df, city: struct_extract(address, "city"))
+
+  **Math:**
+
+      Dux.mutate(df, log_amt: ln(amount), pct: round(ratio * 100, 2))
+
+  **Null handling:**
+
+      Dux.mutate(df, safe: coalesce(nullable_col, 0))
+
+  **Type casting:**
+
+      Dux.mutate(df, as_text: cast(id, "VARCHAR"), as_int: cast(amount, "INTEGER"))
+
+  For the full list, see the
+  [DuckDB Functions reference](https://duckdb.org/docs/sql/functions/overview).
+
+  For anything the macro doesn't support (window functions, subqueries),
+  use the `_with` variants (`mutate_with/2`, `filter_with/2`) which accept
+  raw DuckDB SQL strings.
+
+  ## Column references
+
+  `col("name")` for columns with spaces or special characters:
+
+      Dux.filter(df, col("Total Amount") > 100)
 
   ## Examples
 
       # Filter
       Dux.filter(df, age > 18 and status == "active")
 
-      # Mutate
-      Dux.mutate(df, revenue: price * quantity, tax: price * ^tax_rate)
+      # Mutate with conditional
+      Dux.mutate(df,
+        revenue: price * quantity,
+        tier: cond do
+          price > 100 -> "premium"
+          true -> "standard"
+        end
+      )
 
       # Summarise
       Dux.summarise(df, total: sum(amount), n: count(id))
@@ -135,6 +215,49 @@ defmodule Dux.Query do
   defp traverse({:-, _meta, [expr]}, pins) when not is_number(expr) do
     {ast, pins} = traverse(expr, pins)
     {{:negate, ast}, pins}
+  end
+
+  # cond → CASE WHEN ... THEN ... ELSE ... END
+  defp traverse({:cond, _meta, [[do: clauses]]}, pins) do
+    {pairs, else_expr, pins} =
+      Enum.reduce(clauses, {[], nil, pins}, fn {:->, _m, [[condition], result]},
+                                               {pairs, _else, pins} ->
+        {cond_ast, pins} = traverse(condition, pins)
+        {result_ast, pins} = traverse(result, pins)
+
+        case cond_ast do
+          {:lit, true} ->
+            # `true -> expr` becomes the ELSE branch
+            {pairs, result_ast, pins}
+
+          _ ->
+            {pairs ++ [{cond_ast, result_ast}], nil, pins}
+        end
+      end)
+
+    {{:case_when, pairs, else_expr}, pins}
+  end
+
+  # if/else → CASE WHEN cond THEN then_expr ELSE else_expr END
+  defp traverse({:if, _meta, [condition, [do: then_expr, else: else_expr]]}, pins) do
+    {cond_ast, pins} = traverse(condition, pins)
+    {then_ast, pins} = traverse(then_expr, pins)
+    {else_ast, pins} = traverse(else_expr, pins)
+    {{:case_when, [{cond_ast, then_ast}], else_ast}, pins}
+  end
+
+  # if without else → CASE WHEN cond THEN then_expr ELSE NULL END
+  defp traverse({:if, _meta, [condition, [do: then_expr]]}, pins) do
+    {cond_ast, pins} = traverse(condition, pins)
+    {then_ast, pins} = traverse(then_expr, pins)
+    {{:case_when, [{cond_ast, then_ast}], {:lit, nil}}, pins}
+  end
+
+  # in operator → SQL IN
+  defp traverse({:in, _meta, [left, right]}, pins) do
+    {l_ast, pins} = traverse(left, pins)
+    {r_ast, pins} = traverse(right, pins)
+    {{:in, l_ast, r_ast}, pins}
   end
 
   # String concatenation: <>

--- a/lib/dux/query/compiler.ex
+++ b/lib/dux/query/compiler.ex
@@ -139,6 +139,57 @@ defmodule Dux.Query.Compiler do
     {"#{sql_name}(#{Enum.join(arg_sqls, ", ")})", all_params, idx}
   end
 
+  # --- CASE WHEN ---
+
+  defp compile({:case_when, pairs, else_expr}, pins, idx) do
+    {when_clauses, all_params, idx} =
+      Enum.reduce(pairs, {[], [], idx}, fn {condition, result}, {clauses, params, idx} ->
+        {cond_sql, cond_params, idx} = compile(condition, pins, idx)
+        {result_sql, result_params, idx} = compile(result, pins, idx)
+        clause = "WHEN #{cond_sql} THEN #{result_sql}"
+        {clauses ++ [clause], params ++ cond_params ++ result_params, idx}
+      end)
+
+    {else_clause, else_params, idx} =
+      case else_expr do
+        nil ->
+          {"", [], idx}
+
+        expr ->
+          {sql, params, idx} = compile(expr, pins, idx)
+          {" ELSE #{sql}", params, idx}
+      end
+
+    sql = "(CASE #{Enum.join(when_clauses, " ")}#{else_clause} END)"
+    {sql, all_params ++ else_params, idx}
+  end
+
+  # --- IN operator ---
+
+  defp compile({:in, left, {:pin, pin_idx}}, pins, idx) do
+    {l_sql, l_params, idx} = compile(left, pins, idx)
+    values = Enum.at(pins, pin_idx)
+    # Pinned list — expand to individual parameter bindings
+    {placeholders, idx} =
+      Enum.reduce(values, {[], idx}, fn _v, {phs, idx} ->
+        {phs ++ ["$#{idx + 1}"], idx + 1}
+      end)
+
+    {"(#{l_sql} IN (#{Enum.join(placeholders, ", ")}))", l_params ++ values, idx}
+  end
+
+  defp compile({:in, left, right}, pins, idx) when is_list(right) do
+    {l_sql, l_params, idx} = compile(left, pins, idx)
+
+    {val_sqls, val_params, idx} =
+      Enum.reduce(right, {[], [], idx}, fn item, {sqls, params, idx} ->
+        {sql, new_params, idx} = compile(item, pins, idx)
+        {sqls ++ [sql], params ++ new_params, idx}
+      end)
+
+    {"(#{l_sql} IN (#{Enum.join(val_sqls, ", ")}))", l_params ++ val_params, idx}
+  end
+
   # --- Sort direction markers ---
 
   defp compile({:asc, expr}, pins, idx) do

--- a/test/dux/query_test.exs
+++ b/test/dux/query_test.exs
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file Credo.Check.Refactor.CondStatements
 defmodule Dux.QueryTest do
   use ExUnit.Case, async: false
   require Dux
@@ -303,6 +304,345 @@ defmodule Dux.QueryTest do
                %{"region" => "EU", "total" => 150, "n" => 1},
                %{"region" => "US", "total" => 200, "n" => 1}
              ] = result
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # CASE WHEN (cond/if)
+  # ---------------------------------------------------------------------------
+
+  describe "cond → CASE WHEN" do
+    test "basic cond with else" do
+      result =
+        Dux.from_list([%{"x" => 10}, %{"x" => 200}, %{"x" => 1500}])
+        |> Dux.mutate(
+          tier:
+            cond do
+              x > 1000 -> "gold"
+              x > 100 -> "silver"
+              true -> "bronze"
+            end
+        )
+        |> Dux.sort_by(:x)
+        |> Dux.to_columns()
+
+      assert result["tier"] == ["bronze", "silver", "gold"]
+    end
+
+    test "cond without else (no true branch)" do
+      result =
+        Dux.from_list([%{"x" => 5}, %{"x" => 15}])
+        |> Dux.mutate(
+          label:
+            cond do
+              x > 10 -> "big"
+            end
+        )
+        |> Dux.sort_by(:x)
+        |> Dux.to_columns()
+
+      # No else → NULL for non-matching rows
+      assert result["label"] == [nil, "big"]
+    end
+
+    test "cond with pins" do
+      threshold = 100
+
+      result =
+        Dux.from_list([%{"x" => 50}, %{"x" => 150}])
+        |> Dux.mutate(
+          over:
+            cond do
+              x > ^threshold -> "yes"
+              true -> "no"
+            end
+        )
+        |> Dux.sort_by(:x)
+        |> Dux.to_columns()
+
+      assert result["over"] == ["no", "yes"]
+    end
+
+    test "cond in filter" do
+      result =
+        Dux.from_list([%{"x" => 1}, %{"x" => 2}, %{"x" => 3}])
+        |> Dux.filter(
+          cond do
+            x > 2 -> true
+            true -> false
+          end
+        )
+        |> Dux.to_columns()
+
+      assert result["x"] == [3]
+    end
+
+    test "nested cond with arithmetic" do
+      result =
+        Dux.from_list([%{"amount" => 50}, %{"amount" => 500}, %{"amount" => 5000}])
+        |> Dux.mutate(
+          discount:
+            cond do
+              amount > 1000 -> amount * 0.2
+              amount > 100 -> amount * 0.1
+              true -> 0
+            end
+        )
+        |> Dux.sort_by(:amount)
+        |> Dux.to_rows()
+
+      assert Enum.map(result, & &1["discount"]) == [0, 50.0, 1000.0]
+    end
+  end
+
+  describe "if/else → CASE WHEN" do
+    test "basic if/else" do
+      result =
+        Dux.from_list([%{"x" => -5}, %{"x" => 10}])
+        |> Dux.mutate(sign: if(x > 0, do: "positive", else: "non-positive"))
+        |> Dux.sort_by(:x)
+        |> Dux.to_columns()
+
+      assert result["sign"] == ["non-positive", "positive"]
+    end
+
+    test "if without else (NULL)" do
+      result =
+        Dux.from_list([%{"x" => 1}, %{"x" => 5}])
+        |> Dux.mutate(big: if(x > 3, do: "yes"))
+        |> Dux.sort_by(:x)
+        |> Dux.to_columns()
+
+      assert result["big"] == [nil, "yes"]
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # IN operator
+  # ---------------------------------------------------------------------------
+
+  describe "in operator" do
+    test "literal list" do
+      result =
+        Dux.from_list([%{"x" => 1}, %{"x" => 2}, %{"x" => 3}, %{"x" => 4}])
+        |> Dux.filter(x in [2, 4])
+        |> Dux.to_columns()
+
+      assert result["x"] == [2, 4]
+    end
+
+    test "pinned list" do
+      allowed = [1, 3]
+
+      result =
+        Dux.from_list([%{"x" => 1}, %{"x" => 2}, %{"x" => 3}, %{"x" => 4}])
+        |> Dux.filter(x in ^allowed)
+        |> Dux.to_columns()
+
+      assert result["x"] == [1, 3]
+    end
+
+    test "string values" do
+      result =
+        Dux.from_list([
+          %{"status" => "active"},
+          %{"status" => "pending"},
+          %{"status" => "deleted"}
+        ])
+        |> Dux.filter(status in ["active", "pending"])
+        |> Dux.sort_by(:status)
+        |> Dux.to_columns()
+
+      assert result["status"] == ["active", "pending"]
+    end
+
+    test "pinned string list" do
+      allowed = ["active", "pending"]
+
+      result =
+        Dux.from_list([
+          %{"status" => "active"},
+          %{"status" => "pending"},
+          %{"status" => "deleted"}
+        ])
+        |> Dux.filter(status in ^allowed)
+        |> Dux.sort_by(:status)
+        |> Dux.to_columns()
+
+      assert result["status"] == ["active", "pending"]
+    end
+
+    test "single value" do
+      result =
+        Dux.from_list([%{"x" => 1}, %{"x" => 2}])
+        |> Dux.filter(x in [1])
+        |> Dux.to_columns()
+
+      assert result["x"] == [1]
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # CASE WHEN / IN — adversarial
+  # ---------------------------------------------------------------------------
+
+  describe "cond/in adversarial" do
+    test "cond with SQL-injection-like strings" do
+      result =
+        Dux.from_list([%{"x" => 1}])
+        |> Dux.mutate(
+          label:
+            cond do
+              x > 0 -> "it's a 'test'"
+              true -> "other"
+            end
+        )
+        |> Dux.to_rows()
+
+      assert hd(result)["label"] == "it's a 'test'"
+    end
+
+    test "cond with many branches" do
+      result =
+        Dux.from_list([%{"x" => 1}, %{"x" => 2}, %{"x" => 3}, %{"x" => 4}, %{"x" => 5}])
+        |> Dux.mutate(
+          label:
+            cond do
+              x == 1 -> "one"
+              x == 2 -> "two"
+              x == 3 -> "three"
+              x == 4 -> "four"
+              true -> "other"
+            end
+        )
+        |> Dux.sort_by(:x)
+        |> Dux.to_columns()
+
+      assert result["label"] == ["one", "two", "three", "four", "other"]
+    end
+
+    test "in with empty result" do
+      result =
+        Dux.from_list([%{"x" => 1}, %{"x" => 2}])
+        |> Dux.filter(x in [99, 100])
+        |> Dux.to_columns()
+
+      assert result["x"] == []
+    end
+
+    test "in combined with cond" do
+      result =
+        Dux.from_list([
+          %{"status" => "active", "amount" => 50},
+          %{"status" => "pending", "amount" => 200},
+          %{"status" => "deleted", "amount" => 100}
+        ])
+        |> Dux.filter(status in ["active", "pending"])
+        |> Dux.mutate(
+          tier:
+            cond do
+              amount > 100 -> "high"
+              true -> "low"
+            end
+        )
+        |> Dux.sort_by(:amount)
+        |> Dux.to_rows()
+
+      assert length(result) == 2
+      assert Enum.map(result, & &1["tier"]) == ["low", "high"]
+    end
+
+    test "cond with null values" do
+      result =
+        Dux.from_query("SELECT NULL AS x UNION ALL SELECT 5 AS x")
+        |> Dux.mutate(
+          label:
+            cond do
+              x > 3 -> "big"
+              true -> "small"
+            end
+        )
+        |> Dux.sort_by(:label)
+        |> Dux.to_columns()
+
+      # NULL > 3 is NULL (falsy), so falls to else
+      assert result["label"] == ["big", "small"]
+    end
+
+    test "pinned in with special characters in strings" do
+      targets = ["it's", "a \"test\""]
+
+      result =
+        Dux.from_list([
+          %{"name" => "it's"},
+          %{"name" => "a \"test\""},
+          %{"name" => "other"}
+        ])
+        |> Dux.filter(name in ^targets)
+        |> Dux.sort_by(:name)
+        |> Dux.to_columns()
+
+      assert length(result["name"]) == 2
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # DuckDB function pass-through
+  # ---------------------------------------------------------------------------
+
+  describe "DuckDB function pass-through" do
+    test "date functions" do
+      result =
+        Dux.from_query("SELECT DATE '2024-06-15' AS d")
+        |> Dux.mutate(y: year(d), m: month(d), day_of: day(d))
+        |> Dux.to_rows()
+
+      row = hd(result)
+      assert row["y"] == 2024
+      assert row["m"] == 6
+      assert row["day_of"] == 15
+    end
+
+    test "string functions" do
+      result =
+        Dux.from_list([%{"name" => "Hello World"}])
+        |> Dux.mutate(low: lower(name), up: upper(name), len: length(name))
+        |> Dux.to_rows()
+
+      row = hd(result)
+      assert row["low"] == "hello world"
+      assert row["up"] == "HELLO WORLD"
+      assert row["len"] == 11
+    end
+
+    test "math functions" do
+      result =
+        Dux.from_list([%{"x" => 100}])
+        |> Dux.mutate(sq: sqrt(x), lg: log2(x), ab: abs(-1 * x))
+        |> Dux.to_rows()
+
+      row = hd(result)
+      assert row["sq"] == 10.0
+      assert_in_delta row["lg"], 6.644, 0.01
+      assert row["ab"] == 100
+    end
+
+    test "coalesce" do
+      result =
+        Dux.from_query("SELECT NULL AS x, 42 AS y")
+        |> Dux.mutate(z: coalesce(x, y))
+        |> Dux.to_rows()
+
+      assert hd(result)["z"] == 42
+    end
+
+    test "regexp_matches" do
+      result =
+        Dux.from_list([%{"email" => "a@gmail.com"}, %{"email" => "b@yahoo.com"}])
+        |> Dux.filter(regexp_matches(email, ".*@gmail\\.com"))
+        |> Dux.to_columns()
+
+      assert result["email"] == ["a@gmail.com"]
     end
   end
 end


### PR DESCRIPTION
## Summary

### Query macro enrichment
- **`cond`** → `CASE WHEN`: multi-branch conditional expressions compile to SQL CASE WHEN
- **`if/else`** → simple two-branch CASE WHEN
- **`in`** → `IN (...)`: membership test with literal lists and pinned (parameterized) lists

### Documentation
- Expanded `Dux.Query` moduledoc with all operators, conditionals, IN, and comprehensive DuckDB function examples by category (date, string, regex, list, struct, math, null, type casting)
- Updated getting-started guide: new sections for conditional expressions, membership tests, DuckDB functions, and `compute/1` in materialization
- Updated README: cond/in examples and note that all DuckDB functions work in expressions

### Examples
```elixir
# CASE WHEN
Dux.mutate(df,
  tier: cond do
    amount > 1000 -> "gold"
    amount > 100 -> "silver"
    true -> "bronze"
  end
)

# IN
Dux.filter(df, status in ["active", "pending"])
Dux.filter(df, status in ^allowed_statuses)

# All DuckDB functions work
Dux.mutate(df, y: year(date_col), low: lower(name))
```

## Test plan

- [x] 52 query tests — happy path, adversarial (SQL injection, nulls, many branches), combined cond+in, function pass-through
- [x] 635 total tests pass, 0 failures
- [x] Credo strict clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)