### PR TITLE
Use IPC instead of Elixir rows for table replication (15.9x faster)

### DIFF
--- a/lib/dux/inspect.ex
+++ b/lib/dux/inspect.ex
@@ -160,6 +160,7 @@ defimpl Inspect, for: Dux do
   defp describe_source({:parquet, path, _}), do: "parquet: #{Path.basename(path)}"
   defp describe_source({:ndjson, path, _}), do: "ndjson: #{Path.basename(path)}"
   defp describe_source({:list, rows}), do: "list: #{length(rows)} rows"
+  defp describe_source({:ipc, binary}), do: "ipc: #{div(byte_size(binary), 1024)} KB"
   defp describe_source({:table, _}), do: "table"
   defp describe_source(nil), do: "empty"
   defp describe_source(other), do: Kernel.inspect(other)

--- a/lib/dux/query_builder.ex
+++ b/lib/dux/query_builder.ex
@@ -33,6 +33,17 @@ defmodule Dux.QueryBuilder do
     end
   end
 
+  @doc """
+  Clear any IPC table refs stored in the process dictionary.
+
+  Call this after query execution to allow temp tables created from
+  `{:ipc, binary}` sources to be garbage collected.
+  """
+  def clear_ipc_refs do
+    Process.delete(:dux_ipc_refs)
+    :ok
+  end
+
   # ---------------------------------------------------------------------------
   # Source SQL generation
   # ---------------------------------------------------------------------------
@@ -99,6 +110,15 @@ defmodule Dux.QueryBuilder do
           {~s(SELECT * FROM "#{escape_sql_string(table_ref.name)}"), []}
         end
     end
+  end
+
+  defp source_to_sql({:ipc, binary}, conn) when is_binary(binary) do
+    table_ref = Dux.Backend.table_from_ipc(conn, binary)
+    # Keep ref alive in process dictionary to prevent GC before query executes.
+    # Cleaned up by clear_ipc_refs/0 after query completion.
+    existing = Process.get(:dux_ipc_refs, [])
+    Process.put(:dux_ipc_refs, [table_ref | existing])
+    {~s(SELECT * FROM "#{escape_sql_string(table_ref.name)}"), []}
   end
 
   defp source_to_sql({:parquet, path, opts}, _db) do

--- a/lib/dux/remote/partitioner.ex
+++ b/lib/dux/remote/partitioner.ex
@@ -221,11 +221,12 @@ defmodule Dux.Remote.Partitioner do
   # ---------------------------------------------------------------------------
 
   # Replicate: every worker gets the same pipeline.
-  # Table refs are connection-local — convert to list source for workers.
+  # Table refs are connection-local — serialize to IPC for workers.
+  # IPC is compact Arrow binary that workers deserialize via zero-copy ingest.
   defp replicate(%Dux{source: {:table, %Dux.TableRef{} = ref}} = pipeline, workers) do
     conn = Dux.Connection.get_conn()
-    rows = Dux.Backend.table_to_rows(conn, ref)
-    worker_pipeline = %{pipeline | source: {:list, rows}}
+    ipc = Dux.Backend.table_to_ipc(conn, ref)
+    worker_pipeline = %{pipeline | source: {:ipc, ipc}}
     Enum.map(workers, fn worker -> {worker, worker_pipeline} end)
   end
 

--- a/lib/dux/remote/shuffle.ex
+++ b/lib/dux/remote/shuffle.ex
@@ -172,8 +172,8 @@ defmodule Dux.Remote.Shuffle do
 
   defp ensure_worker_safe(%Dux{source: {:table, %Dux.TableRef{} = ref}} = pipeline) do
     conn = Dux.Connection.get_conn()
-    rows = Dux.Backend.table_to_rows(conn, ref)
-    %{pipeline | source: {:list, rows}}
+    ipc = Dux.Backend.table_to_ipc(conn, ref)
+    %{pipeline | source: {:ipc, ipc}}
   end
 
   defp ensure_worker_safe(pipeline), do: pipeline

--- a/lib/dux/remote/worker.ex
+++ b/lib/dux/remote/worker.ex
@@ -176,6 +176,8 @@ defmodule Dux.Remote.Worker do
         {:ok, ipc}
       rescue
         e -> {:error, Exception.message(e)}
+      after
+        Dux.QueryBuilder.clear_ipc_refs()
       end
 
     {:reply, result, state}
@@ -247,6 +249,8 @@ defmodule Dux.Remote.Worker do
         {:ok, buckets}
       rescue
         e -> {:error, Exception.message(e)}
+      after
+        Dux.QueryBuilder.clear_ipc_refs()
       end
 
     {:reply, result, state}
@@ -309,6 +313,8 @@ defmodule Dux.Remote.Worker do
         result
       rescue
         e -> {:error, Exception.message(e)}
+      after
+        Dux.QueryBuilder.clear_ipc_refs()
       end
 
     {:reply, result, state}
@@ -346,6 +352,8 @@ defmodule Dux.Remote.Worker do
         result
       rescue
         e -> {:error, Exception.message(e)}
+      after
+        Dux.QueryBuilder.clear_ipc_refs()
       end
 
     {:reply, result, state}


### PR DESCRIPTION
## Summary

When a computed `%Dux{}` (table ref) is distributed to workers, it was going through Elixir rows:
1. `table_to_rows` → list of maps (expensive materialization)
2. Sent as `{:list, rows}` in pipeline struct (large Erlang term)
3. Workers re-ingest via `rows_to_columns` → ADBC (rebuild Arrow from scratch)

Now uses Arrow IPC — the same binary format workers already use for results:
1. `table_to_ipc` → compact Arrow binary
2. Sent as `{:ipc, binary}` (binary copy, no term encoding)
3. Workers `table_from_ipc` → zero-copy ADBC ingest

Changes:
- Add `{:ipc, binary}` source type in `QueryBuilder`
- `Partitioner.replicate/2` uses IPC instead of rows
- `Shuffle.ensure_worker_safe/1` uses IPC instead of rows
- `Inspect` handles `{:ipc, _}` source display

## Benchmark (2 local workers)

| Benchmark | Before (median) | After (median) | Speedup |
|-----------|-----------------|----------------|---------|
| Replicate 1K rows | 16ms | 27ms | ~same (IPC overhead on small data) |
| Replicate 10K rows | 381ms | 24ms | **15.9x** |
| Broadcast join (computed right) | 260ms | 72ms | **3.6x** |

## Test plan

- [x] 29 distributed tests pass (0 failures)
- [x] Credo strict clean
- [x] Benchmarks before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)