### PR TITLE
Per-worker stats in meta, fix status for FLAME

### DIFF
--- a/lib/dux/flame.ex
+++ b/lib/dux/flame.ex
@@ -58,8 +58,6 @@ if Code.ensure_loaded?(FLAME) do
     After idle timeout, FLAME auto-terminates the runners.
     """
 
-    alias Dux.Remote.Worker
-
     @default_pool Dux.FlamePool
 
     @doc """
@@ -104,15 +102,16 @@ if Code.ensure_loaded?(FLAME) do
     end
 
     @doc """
-    Get status of the FLAME-backed Dux cluster.
+    Get status of the Dux worker cluster.
 
-    Pass the workers list returned by `spin_up/2`, or omit to
-    discover workers via `:pg` (may not find remote FLAME workers).
+    Pass the workers list returned by `spin_up/2`.
 
-    Returns worker count grouped by node, with alive status.
+        workers = Dux.Flame.spin_up(3, pool: :dux_pool)
+        Dux.Flame.status(workers)
+        # => %{total_workers: 3, nodes: %{:"flame-abc@..." => 1, ...}, ...}
+
+    Returns worker count grouped by node.
     """
-    def status(workers_or_pool \\ @default_pool)
-
     def status(workers) when is_list(workers) do
       nodes =
         workers
@@ -123,21 +122,6 @@ if Code.ensure_loaded?(FLAME) do
         total_workers: length(workers),
         nodes: nodes,
         worker_pids: workers
-      }
-    end
-
-    def status(pool) when is_atom(pool) do
-      workers = Worker.list()
-
-      nodes =
-        workers
-        |> Enum.group_by(&node/1)
-        |> Map.new(fn {n, pids} -> {n, length(pids)} end)
-
-      %{
-        pool: pool,
-        total_workers: length(workers),
-        nodes: nodes
       }
     end
   end

--- a/lib/dux/remote/coordinator.ex
+++ b/lib/dux/remote/coordinator.ex
@@ -110,12 +110,14 @@ defmodule Dux.Remote.Coordinator do
       System.convert_time_unit(System.monotonic_time() - start_time, :native, :millisecond)
 
     nodes = workers |> Enum.map(&node/1) |> Enum.uniq()
+    worker_stats = Process.delete(:dux_worker_stats) || []
 
     meta = %{
       distributed: true,
       n_workers: length(workers),
       n_nodes: length(nodes),
       nodes: nodes,
+      worker_stats: worker_stats,
       merge_strategy: if(streaming?, do: :streaming, else: :batch),
       total_duration_ms: total_ms
     }
@@ -167,7 +169,8 @@ defmodule Dux.Remote.Coordinator do
         {r, %{n_workers: n_workers}}
       end)
 
-    {successes, failures} = partition_results(results)
+    {successes, worker_stats, failures} = partition_results(results)
+    Process.put(:dux_worker_stats, worker_stats)
 
     if successes == [] do
       reasons = Enum.map(failures, fn {:error, reason} -> reason end)
@@ -312,6 +315,7 @@ defmodule Dux.Remote.Coordinator do
         case result do
           {:ok, ipc} ->
             duration = System.monotonic_time() - start_time
+            duration_ms = System.convert_time_unit(duration, :native, :millisecond)
 
             :telemetry.execute(
               [:dux, :distributed, :worker, :stop],
@@ -319,18 +323,19 @@ defmodule Dux.Remote.Coordinator do
               %{worker: worker, worker_index: idx, n_workers: n_workers}
             )
 
-          _ ->
-            :ok
-        end
+            stat = %{node: node(worker), duration_ms: duration_ms, ipc_bytes: byte_size(ipc)}
+            {:ok, ipc, stat}
 
-        result
+          _ ->
+            result
+        end
       end,
       timeout: timeout,
       max_concurrency: n_workers,
       ordered: false
     )
     |> Enum.map(fn
-      {:ok, {:ok, ipc}} -> {:ok, ipc}
+      {:ok, {:ok, ipc, stat}} -> {:ok, ipc, stat}
       {:ok, {:error, reason}} -> {:error, reason}
       {:exit, reason} -> {:error, {:worker_crash, reason}}
     end)
@@ -338,11 +343,13 @@ defmodule Dux.Remote.Coordinator do
 
   defp partition_results(results) do
     Enum.split_with(results, fn
-      {:ok, _} -> true
+      {:ok, _, _} -> true
       _ -> false
     end)
     |> then(fn {ok, err} ->
-      {Enum.map(ok, fn {:ok, ipc} -> ipc end), err}
+      ipcs = Enum.map(ok, fn {:ok, ipc, _stat} -> ipc end)
+      stats = Enum.map(ok, fn {:ok, _ipc, stat} -> stat end)
+      {ipcs, stats, err}
     end)
   end
 

--- a/test/dux/flame_test.exs
+++ b/test/dux/flame_test.exs
@@ -94,14 +94,6 @@ if Code.ensure_loaded?(FLAME) do
         assert is_map(status.nodes)
         assert is_list(status.worker_pids)
       end
-
-      test "returns cluster info with pool name", %{pool: pool} do
-        _workers = Dux.Flame.spin_up(2, pool: pool)
-        status = Dux.Flame.status(pool)
-
-        assert status.total_workers >= 0
-        assert is_map(status.nodes)
-      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- **Per-worker execution stats**: `fan_out` now captures `%{node, duration_ms, ipc_bytes}` per worker and attaches to `meta.worker_stats`
- **Remove broken `status(pool)` overload**: `:pg` doesn't propagate across FLAME nodes, so the pool-name discovery path always returned 0 workers. Only `status(workers)` with the list from `spin_up` works.

## Usage

```elixir
result = pipeline |> Dux.distribute(workers) |> Dux.compute()
result.meta.worker_stats
# => [
#   %{node: :"flame-abc@...", duration_ms: 1200, ipc_bytes: 42_000_000},
#   %{node: :"flame-def@...", duration_ms: 1400, ipc_bytes: 44_000_000},
#   ...
# ]

Dux.Flame.status(workers)
# => %{total_workers: 3, nodes: %{...}, worker_pids: [...]}
```

## Test plan

- [x] 42 tests pass (0 failures)
- [x] Credo strict clean
- [x] No performance cost — stats use O(1) operations on existing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)