### PR TITLE
perf: eliminate data round-trip in Backend.query/2

### DIFF
--- a/bench/core_bench.exs
+++ b/bench/core_bench.exs
@@ -9,8 +9,13 @@ alias Dux.Remote.Worker
 
 IO.puts("Setting up benchmark data...")
 
-# Small dataset (1K rows)
+# Small dataset (100 rows)
 small_data = for i <- 1..100, do: %{"id" => i, "group" => rem(i, 10), "value" => i * 1.5}
+
+# Large from_list dataset (5K rows, atom keys)
+large_list_data =
+  for i <- 1..5_000,
+      do: %{id: i, group: rem(i, 100), value: i * 1.5, label: "item_#{i}"}
 
 # Medium dataset (100K via DuckDB)
 medium_sql = "SELECT x AS id, x % 100 AS grp, x * 1.5 AS value FROM range(100000) t(x)"
@@ -39,6 +44,9 @@ Benchee.run(
     # --- Construction ---
     "from_list (100 rows)" => fn ->
       Dux.from_list(small_data) |> Dux.compute()
+    end,
+    "from_list (5K rows)" => fn ->
+      Dux.from_list(large_list_data) |> Dux.compute()
     end,
     "from_query (100K rows)" => fn ->
       Dux.from_query(medium_sql) |> Dux.compute()
@@ -89,6 +97,44 @@ Benchee.run(
     # --- Computed base + chained ops ---
     "chained from computed (100K): filter → head" => fn ->
       medium_computed |> Dux.filter_with("value > 75000") |> Dux.head(100) |> Dux.compute()
+    end
+  },
+  warmup: 1,
+  time: 5,
+  memory_time: 2,
+  print: [configuration: false]
+)
+
+# ---------------------------------------------------------------------------
+# Scale benchmarks (1M rows — catches materialization regressions)
+# ---------------------------------------------------------------------------
+
+IO.puts("\n--- Scale benchmarks (1M rows) ---\n")
+
+large_computed = Dux.from_query(large_sql) |> Dux.compute()
+
+Benchee.run(
+  %{
+    "filter (1M → ~500K)" => fn ->
+      Dux.from_query(large_sql) |> Dux.filter_with("value > 750000") |> Dux.compute()
+    end,
+    "filter from computed (1M → ~500K)" => fn ->
+      large_computed |> Dux.filter_with("value > 750000") |> Dux.compute()
+    end,
+    "mutate (1M rows)" => fn ->
+      large_computed |> Dux.mutate_with(doubled: "value * 2") |> Dux.compute()
+    end,
+    "group_by + summarise (1M → 1K groups)" => fn ->
+      large_computed
+      |> Dux.group_by(:grp)
+      |> Dux.summarise_with(total: "SUM(value)", n: "COUNT(*)")
+      |> Dux.compute()
+    end,
+    "to_rows (10K)" => fn ->
+      large_computed |> Dux.head(10_000) |> Dux.to_rows()
+    end,
+    "to_rows (50K)" => fn ->
+      large_computed |> Dux.head(50_000) |> Dux.to_rows()
     end
   },
   warmup: 1,

--- a/lib/dux.ex
+++ b/lib/dux.ex
@@ -135,7 +135,25 @@ defmodule Dux do
       %{"age" => [30, 25], "name" => ["Alice", "Bob"]}
   """
   def from_list(rows) when is_list(rows) do
-    %Dux{source: {:list, rows}}
+    if length(rows) > 500 do
+      # Eagerly ingest large lists into DuckDB so the data lives in the engine.
+      # Without this, every compute() re-transposes and re-ingests from Elixir maps.
+      conn = Dux.Connection.get_conn()
+      columns = Dux.QueryBuilder.rows_to_columns(rows)
+      ingest_result = Adbc.Connection.ingest!(conn, columns)
+
+      table_ref = %Dux.TableRef{
+        name: ingest_result.table,
+        gc_ref: ingest_result,
+        node: node()
+      }
+
+      names = Dux.Backend.table_names(conn, table_ref)
+      dtypes = Dux.Backend.table_dtypes(conn, table_ref) |> Map.new()
+      %Dux{source: {:table, table_ref}, names: names, dtypes: dtypes}
+    else
+      %Dux{source: {:list, rows}}
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/dux.ex
+++ b/lib/dux.ex
@@ -1425,6 +1425,7 @@ defmodule Dux do
       result = %Dux{source: {:table, table_ref}, names: names, dtypes: dtypes}
 
       Process.delete(:dux_compute_ref)
+      Dux.QueryBuilder.clear_ipc_refs()
       {:table, table_ref} = result.source
       {result, Map.put(meta, :n_rows, Dux.Backend.table_n_rows(conn, table_ref))}
     end)

--- a/lib/dux/backend.ex
+++ b/lib/dux/backend.ex
@@ -40,76 +40,25 @@ defmodule Dux.Backend do
 
   @doc false
   def query(conn, sql) do
-    result =
-      case Adbc.Connection.query(conn, sql) do
-        {:ok, r} ->
-          r
+    # Data stays in DuckDB — no Elixir materialization.
+    # GC ref via Adbc.Nif.adbc_delete_on_gc_new/2 auto-drops the table
+    # when the TableRef is garbage collected (same mechanism ADBC uses
+    # internally for Adbc.Connection.ingest!/2 results).
+    name = "__dux_#{:erlang.unique_integer([:positive])}"
 
-        {:error, %Adbc.Error{} = err} ->
-          raise ArgumentError, "DuckDB query failed: #{err.message}"
+    case Adbc.Connection.query(conn, "CREATE TEMPORARY TABLE #{qi(name)} AS (#{sql})") do
+      {:ok, _} ->
+        :ok
 
-        {:error, err} ->
-          raise ArgumentError, "DuckDB query failed: #{Exception.message(err)}"
-      end
+      {:error, %Adbc.Error{} = err} ->
+        raise ArgumentError, "DuckDB query failed: #{err.message}"
 
-    materialized = Adbc.Result.materialize(result)
-
-    case flatten_batches(materialized.data) do
-      [] ->
-        # ADBC returns empty data for 0-row results. Can't ingest empty columns.
-        # Create the temp table via SQL to preserve the schema.
-        create_table_from_sql(conn, sql)
-
-      :multi_batch ->
-        # Multiple record batches — fall back to SQL to avoid concatenation.
-        create_table_with_data(conn, sql)
-
-      columns ->
-        # Single batch — ingest directly (avoids SQL round-trip).
-        if has_special_column_names?(columns) do
-          create_table_with_data(conn, sql)
-        else
-          try do
-            ingest_result = Adbc.Connection.ingest!(conn, columns)
-
-            %TableRef{
-              name: ingest_result.table,
-              gc_ref: ingest_result,
-              node: node()
-            }
-          rescue
-            ArgumentError ->
-              # ADBC ingest doesn't support all DuckDB types (e.g. timestamps
-              # from postgres_scanner). Fall back to CREATE TABLE AS SELECT.
-              create_table_with_data(conn, sql)
-          end
-        end
+      {:error, err} ->
+        raise ArgumentError, "DuckDB query failed: #{Exception.message(err)}"
     end
-  end
 
-  # Create a temp table from SQL, preserving schema but no data.
-  defp create_table_from_sql(conn, sql) do
-    name = "__dux_#{:erlang.unique_integer([:positive])}"
-
-    Adbc.Connection.query!(
-      conn,
-      "CREATE TEMPORARY TABLE #{qi(name)} AS SELECT * FROM (#{sql}) __src WHERE false"
-    )
-
-    %TableRef{name: name, gc_ref: nil, node: node()}
-  end
-
-  # Create a temp table from SQL, preserving both schema and data.
-  # Used when column names contain special characters that break ADBC ingest.
-  defp create_table_with_data(conn, sql) do
-    name = "__dux_#{:erlang.unique_integer([:positive])}"
-
-    Adbc.Connection.query!(
-      conn,
-      "CREATE TEMPORARY TABLE #{qi(name)} AS SELECT * FROM (#{sql}) __src"
-    )
-
-    %TableRef{name: name, gc_ref: nil, node: node()}
+    gc_ref = Adbc.Nif.adbc_delete_on_gc_new(conn, name)
+    %TableRef{name: name, gc_ref: gc_ref, node: node()}
   end
 
   # ---------------------------------------------------------------------------
@@ -205,14 +154,15 @@ defmodule Dux.Backend do
 
   defp build_rows_from_map(map) do
     col_names = Map.keys(map)
-    values = Map.new(map, fn {k, vs} -> {k, Enum.map(vs, &normalize_value/1)} end)
-    n = values |> Map.values() |> hd() |> length()
 
-    for i <- 0..(n - 1) do
-      Map.new(col_names, fn col ->
-        {col, Enum.at(Map.fetch!(values, col), i)}
+    columns =
+      Enum.map(col_names, fn col ->
+        Enum.map(Map.fetch!(map, col), &normalize_value/1)
       end)
-    end
+
+    Enum.zip_with(columns, fn values ->
+      Enum.zip(col_names, values) |> Map.new()
+    end)
   end
 
   # ---------------------------------------------------------------------------
@@ -258,7 +208,8 @@ defmodule Dux.Backend do
     # Empty sentinel — no columns
     name = "__dux_#{:erlang.unique_integer([:positive])}"
     Adbc.Connection.query!(conn, "CREATE TEMPORARY TABLE #{qi(name)} AS SELECT 1 WHERE false")
-    %TableRef{name: name, gc_ref: nil, node: node()}
+    gc_ref = Adbc.Nif.adbc_delete_on_gc_new(conn, name)
+    %TableRef{name: name, gc_ref: gc_ref, node: node()}
   end
 
   def table_from_ipc(conn, <<"DUX_EMPTY"::binary, ipc::binary>>) do
@@ -302,7 +253,8 @@ defmodule Dux.Backend do
           "CREATE TEMPORARY TABLE #{qi(name)} AS SELECT 1 WHERE false"
         )
 
-        %TableRef{name: name, gc_ref: nil, node: node()}
+        gc_ref = Adbc.Nif.adbc_delete_on_gc_new(conn, name)
+        %TableRef{name: name, gc_ref: gc_ref, node: node()}
       else
         ingest_result = ingest_safe(conn, columns)
         %TableRef{name: ingest_result.table, gc_ref: ingest_result, node: node()}
@@ -352,15 +304,6 @@ defmodule Dux.Backend do
       table: final_name,
       num_rows: ingest_result.num_rows
     }
-  end
-
-  defp has_special_column_names?(columns) do
-    Enum.any?(columns, fn col ->
-      name = col.field.name
-
-      name != String.replace(name, ~r/[^a-zA-Z0-9_]/, "") or
-        String.downcase(name) in @sql_reserved
-    end)
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/dux/connection.ex
+++ b/lib/dux/connection.ex
@@ -44,6 +44,13 @@ defmodule Dux.Connection do
 
     {:ok, db} = Adbc.Database.start_link([driver: :duckdb] ++ db_opts)
     {:ok, conn} = Adbc.Connection.start_link(database: db)
+
+    # Disable insertion order preservation for temp table materialization.
+    # This lets DuckDB parallelize CREATE TABLE AS across threads without
+    # coordinating row order — ~5x faster for large result sets.
+    # Users who need ordered output use Dux.sort_by/2 explicitly.
+    Adbc.Connection.query!(conn, "SET preserve_insertion_order = false")
+
     {:ok, %{db: db, conn: conn}}
   end
 

--- a/lib/dux/query_builder.ex
+++ b/lib/dux/query_builder.ex
@@ -512,6 +512,8 @@ defmodule Dux.QueryBuilder do
   end
 
   # Convert row-oriented list of maps to Adbc.Column format for ingest.
+  # Assumes all rows have the same key type (all atoms or all strings).
+  # Mixed key types will raise on Map.fetch! — callers should normalize first.
   defp rows_to_columns(rows) do
     first_row = hd(rows)
     raw_keys = Map.keys(first_row)
@@ -520,7 +522,7 @@ defmodule Dux.QueryBuilder do
       case hd(raw_keys) do
         k when is_atom(k) ->
           names = raw_keys |> Enum.map(&to_string/1) |> Enum.sort()
-          {names, fn row, name -> Map.fetch!(row, String.to_existing_atom(name)) end}
+          {names, fn row, name -> Map.fetch!(row, String.to_atom(name)) end}
 
         k when is_binary(k) ->
           {Enum.sort(raw_keys), fn row, name -> Map.fetch!(row, name) end}

--- a/lib/dux/query_builder.ex
+++ b/lib/dux/query_builder.ex
@@ -511,10 +511,11 @@ defmodule Dux.QueryBuilder do
     end
   end
 
+  @doc false
   # Convert row-oriented list of maps to Adbc.Column format for ingest.
   # Assumes all rows have the same key type (all atoms or all strings).
   # Mixed key types will raise on Map.fetch! — callers should normalize first.
-  defp rows_to_columns(rows) do
+  def rows_to_columns(rows) do
     first_row = hd(rows)
     raw_keys = Map.keys(first_row)
 

--- a/lib/dux/query_builder.ex
+++ b/lib/dux/query_builder.ex
@@ -107,6 +107,9 @@ defmodule Dux.QueryBuilder do
         else
           columns = rows_to_columns(rows)
           table_ref = ingest_columns(conn, columns)
+          # Keep ref alive in process dictionary to prevent GC before query executes.
+          existing = Process.get(:dux_ipc_refs, [])
+          Process.put(:dux_ipc_refs, [table_ref | existing])
           {~s(SELECT * FROM "#{escape_sql_string(table_ref.name)}"), []}
         end
     end
@@ -510,21 +513,21 @@ defmodule Dux.QueryBuilder do
 
   # Convert row-oriented list of maps to Adbc.Column format for ingest.
   defp rows_to_columns(rows) do
-    # Get all column names from the first row
-    col_names =
-      rows
-      |> hd()
-      |> Map.keys()
-      |> Enum.map(&to_string/1)
-      |> Enum.sort()
+    first_row = hd(rows)
+    raw_keys = Map.keys(first_row)
+
+    {col_names, accessor} =
+      case hd(raw_keys) do
+        k when is_atom(k) ->
+          names = raw_keys |> Enum.map(&to_string/1) |> Enum.sort()
+          {names, fn row, name -> Map.fetch!(row, String.to_existing_atom(name)) end}
+
+        k when is_binary(k) ->
+          {Enum.sort(raw_keys), fn row, name -> Map.fetch!(row, name) end}
+      end
 
     Enum.map(col_names, fn name ->
-      values =
-        Enum.map(rows, fn row ->
-          # Try both string and atom keys
-          Map.get(row, name) || Map.get(row, String.to_atom(name))
-        end)
-
+      values = Enum.map(rows, fn row -> accessor.(row, name) end)
       Adbc.Column.new(values, name: name)
     end)
   end

--- a/lib/dux/query_builder.ex
+++ b/lib/dux/query_builder.ex
@@ -518,19 +518,20 @@ defmodule Dux.QueryBuilder do
     first_row = hd(rows)
     raw_keys = Map.keys(first_row)
 
-    {col_names, accessor} =
+    # Build {string_name, map_key} pairs — string names for ADBC columns,
+    # original keys (atom or string) for Map.fetch! on each row.
+    col_pairs =
       case hd(raw_keys) do
         k when is_atom(k) ->
-          names = raw_keys |> Enum.map(&to_string/1) |> Enum.sort()
-          {names, fn row, name -> Map.fetch!(row, String.to_atom(name)) end}
+          raw_keys |> Enum.map(fn k -> {Atom.to_string(k), k} end) |> Enum.sort()
 
         k when is_binary(k) ->
-          {Enum.sort(raw_keys), fn row, name -> Map.fetch!(row, name) end}
+          raw_keys |> Enum.map(fn k -> {k, k} end) |> Enum.sort()
       end
 
-    Enum.map(col_names, fn name ->
-      values = Enum.map(rows, fn row -> accessor.(row, name) end)
-      Adbc.Column.new(values, name: name)
+    Enum.map(col_pairs, fn {col_name, map_key} ->
+      values = Enum.map(rows, fn row -> Map.fetch!(row, map_key) end)
+      Adbc.Column.new(values, name: col_name)
     end)
   end
 

--- a/test/dux/backend_test.exs
+++ b/test/dux/backend_test.exs
@@ -200,6 +200,100 @@ defmodule Dux.BackendTest do
     end
   end
 
+  # ---------- GC cleanup ----------
+
+  describe "automatic table cleanup via GC" do
+    test "temp table is dropped when TableRef is garbage collected", %{conn: conn} do
+      # Create table in a Task so the ref goes out of scope when the task exits
+      name =
+        Task.async(fn ->
+          ref = Dux.Backend.query(conn, "SELECT 42 AS x")
+          ref.name
+        end)
+        |> Task.await()
+
+      :erlang.garbage_collect()
+      Process.sleep(100)
+
+      # Table should have been dropped by the GC finalizer
+      assert_raise ArgumentError, fn ->
+        Dux.Backend.query(conn, ~s{SELECT * FROM "#{name}"})
+      end
+    end
+
+    test "query/2 always returns a non-nil gc_ref", %{conn: conn} do
+      ref = Dux.Backend.query(conn, "SELECT 1 AS x")
+      assert ref.gc_ref != nil
+    end
+
+    test "table_from_ipc returns non-nil gc_ref", %{conn: conn} do
+      ref = Dux.Backend.query(conn, "SELECT 42 AS x")
+      ipc = Dux.Backend.table_to_ipc(conn, ref)
+      restored = Dux.Backend.table_from_ipc(conn, ipc)
+      assert restored.gc_ref != nil
+    end
+  end
+
+  # ---------- Performance ----------
+
+  describe "performance" do
+    test "query/2 handles large datasets without excess memory", %{conn: conn} do
+      Dux.Backend.execute(
+        conn,
+        "CREATE TABLE perf_src AS SELECT i, CONCAT('row_', i) AS name FROM generate_series(1, 100000) t(i)"
+      )
+
+      {time_us, ref} =
+        :timer.tc(fn ->
+          Dux.Backend.query(conn, "SELECT * FROM perf_src")
+        end)
+
+      assert Dux.Backend.table_n_rows(conn, ref) == 100_000
+      # Should complete in well under 1 second (old materialize+ingest path was much slower)
+      assert time_us < 1_000_000
+    end
+
+    test "to_rows scales linearly (not O(n²))", %{conn: conn} do
+      ref =
+        Dux.Backend.query(
+          conn,
+          "SELECT i AS id, i * 2 AS val FROM generate_series(1, 10000) t(i)"
+        )
+
+      {time_us, rows} =
+        :timer.tc(fn ->
+          Dux.Backend.table_to_rows(conn, ref)
+        end)
+
+      assert length(rows) == 10_000
+      # O(n) should be well under 1 second; O(n²) would be ~160ms+ for 10K
+      assert time_us < 500_000
+    end
+  end
+
+  # ---------- nil/false preservation ----------
+
+  describe "nil and false value preservation" do
+    test "to_rows preserves nil and false values", %{conn: conn} do
+      ref =
+        Dux.Backend.query(
+          conn,
+          "SELECT 1 AS a, NULL AS b, false AS c UNION ALL SELECT 2, 'x', true"
+        )
+
+      rows = Dux.Backend.table_to_rows(conn, ref)
+      assert [%{"a" => 1, "b" => nil, "c" => false}, %{"a" => 2, "b" => "x", "c" => true}] = rows
+    end
+
+    test "to_columns preserves nil and false values", %{conn: conn} do
+      ref =
+        Dux.Backend.query(conn, "SELECT NULL::INTEGER AS x, false AS y UNION ALL SELECT 42, true")
+
+      cols = Dux.Backend.table_to_columns(conn, ref)
+      assert %{"x" => [nil, 42], "y" => [false, true]} = cols
+    end
+  end
+
   # ---------- Wicked / pathological ----------
 
   describe "pathological cases" do


### PR DESCRIPTION
## Summary

- **Backend.query/2**: Replace materialize→ingest round-trip with `CREATE TEMPORARY TABLE AS`. Data never leaves DuckDB. Uses `Adbc.Nif.adbc_delete_on_gc_new/2` for automatic GC cleanup (same NIF mechanism ADBC uses internally).
- **preserve_insertion_order = false**: Set at connection init. DuckDB defaults to maintaining row order during `CREATE TABLE AS`, which prevents parallel materialization. Since Dux doesn't guarantee row order from `compute()` (users use `sort_by/2`), disabling this gives ~5x faster materialization.
- **from_list eager ingestion**: Lists >500 rows are ingested into DuckDB immediately in `from_list`, so the source becomes `{:table, ref}`. Previously every `compute()` re-transposed and re-ingested the entire Elixir list.
- **build_rows_from_map**: Replace O(n²) `Enum.at` index-loop with `Enum.zip_with` — O(n × cols).
- **rows_to_columns**: Detect key type once from first row (single lookup per cell). Fixes bug where `nil`/`false` values with string keys fell through `||` to atom key lookup. No `String.to_atom` on user data.
- **from_list GC race**: Add ref-keeping in process dictionary for ingested tables + cleanup via `clear_ipc_refs()` in local compute path.
- **table_from_ipc GC leak**: Fix `gc_ref: nil` in two fallback paths — these tables were never cleaned up.
- **Scale benchmarks**: Add 1M-row filter/mutate, to_rows 10K/50K, and from_list 5K to `bench/core_bench.exs`.

## Benchmark results

### Before (main) → After (this PR)

#### Core operations (100K rows)

| Operation | Before (median) | After (median) | Speedup |
|-----------|--------|-------|---------|
| from_query 100K | 4.38ms | **2.32ms** | **1.9x** |
| filter 100K | 4.11ms | **2.23ms** | **1.8x** |
| mutate 100K | 5.66ms | **2.98ms** | **1.9x** |
| group+summarise 100K | 4.57ms | **2.40ms** | **1.9x** |
| full pipeline 100K | 3.00ms | **2.77ms** | 1.1x |
| sort 100K | 8.69ms | **4.09ms** | **2.1x** |
| from_query 1M | 39.2ms | **14.3ms** | **2.7x** |
| from_list 5K | 1195ms | **2.07ms** | **577x** |

#### Memory (100K rows)

| Operation | Before | After | Reduction |
|-----------|--------|-------|-----------|
| from_query 100K | 163.7 KB | **16.7 KB** | **9.8x less** |
| filter 100K | 94.0 KB | **19.9 KB** | **4.7x less** |
| mutate 100K | 212.0 KB | **17.7 KB** | **12.0x less** |
| from_query 1M | 1480 KB | **16.7 KB** | **88.6x less** |
| from_list 5K | 30127 KB | **1878 KB** | **16x less** |

#### Scale operations (1M rows)

| Operation | Before (median) | After (median) | Speedup |
|-----------|--------|-------|---------|
| filter from computed 1M | 7.96ms | **2.31ms** | **3.4x** |
| mutate 1M | 20.5ms | **2.54ms** | **8.1x** |
| to_rows 10K | 167ms | **3.94ms** | **42x** |
| to_rows 50K | 3454ms | **17.9ms** | **193x** |

#### Scale memory (1M rows)

| Operation | Before | After | Reduction |
|-----------|--------|-------|-----------|
| filter from computed 1M | 730 KB | **17.6 KB** | **41x less** |
| mutate 1M | 1920 KB | **18.2 KB** | **105x less** |

#### Distributed (no regressions)

| Operation | Before | After |
|-----------|--------|-------|
| distributed 2 workers | 3.24ms | 2.80ms |
| shuffle join 100K×100K | 1.56s | 1.49s |
| broadcast join 100K×20 | 3.69ms | 3.31ms |

#### Alex's Livebook benchmarks (Explorer vs Dux, 10M rows)

| Operation | Explorer | Dux (before) | Dux (after) |
|-----------|----------|-------------|-------------|
| Lazy filter 10M | 13ms | 4347ms (313x slower) | **41ms (3x slower)** |
| Lazy mutate 10M | 14ms | ~4300ms | **~40ms** |
| Lazy summary 10M | 21ms | 7260ms | **~12ms** |

## Test plan

- [x] All 649 existing tests pass (`mix check` — format, compile, test, credo)
- [x] New tests: GC cleanup verified via Task + garbage_collect
- [x] New tests: `gc_ref` is non-nil for `query/2` and `table_from_ipc`
- [x] New tests: performance guards for `query/2` (100K < 1s) and `to_rows` (10K < 0.5s)
- [x] New tests: nil/false value preservation in `to_rows` and `to_columns`
- [x] `bench/core_bench.exs` run before and after — no regressions, major improvements at scale
- [x] Verified with Alex's Livebook benchmarks against Explorer/Polars

🤖 Generated with [Claude Code](https://claude.com/claude-code)