### PR TITLE
feat: connection pool with persistent_term dispatch

### DIFF
--- a/bench/core_bench.exs
+++ b/bench/core_bench.exs
@@ -106,6 +106,36 @@ Benchee.run(
 )
 
 # ---------------------------------------------------------------------------
+# Concurrency benchmark (measures pool throughput vs single connection)
+# ---------------------------------------------------------------------------
+
+IO.puts("\n--- Concurrency benchmark ---\n")
+
+concurrency_computed = Dux.from_query(medium_sql) |> Dux.compute()
+
+Benchee.run(
+  %{
+    "sequential: 10 queries" => fn ->
+      for _ <- 1..10 do
+        concurrency_computed |> Dux.filter_with("value > 75000") |> Dux.compute()
+      end
+    end,
+    "concurrent: 10 queries (Task.async)" => fn ->
+      1..10
+      |> Enum.map(fn _ ->
+        Task.async(fn ->
+          concurrency_computed |> Dux.filter_with("value > 75000") |> Dux.compute()
+        end)
+      end)
+      |> Task.await_many(10_000)
+    end
+  },
+  warmup: 1,
+  time: 5,
+  print: [configuration: false]
+)
+
+# ---------------------------------------------------------------------------
 # Scale benchmarks (1M rows — catches materialization regressions)
 # ---------------------------------------------------------------------------
 
@@ -207,8 +237,11 @@ Benchee.run(
 IO.puts("\n--- Shuffle join benchmark ---\n")
 
 # Two large datasets that will trigger shuffle (both too big for broadcast)
-left_large = Dux.from_query("SELECT x AS id, x % 50 AS key, x * 1.5 AS val FROM range(100000) t(x)")
-right_large = Dux.from_query("SELECT x AS id, x % 50 AS key, x * 2.0 AS score FROM range(100000) t(x)")
+left_large =
+  Dux.from_query("SELECT x AS id, x % 50 AS key, x * 1.5 AS val FROM range(100000) t(x)")
+
+right_large =
+  Dux.from_query("SELECT x AS id, x % 50 AS key, x * 2.0 AS score FROM range(100000) t(x)")
 
 Benchee.run(
   %{
@@ -238,7 +271,9 @@ Benchee.run(
 IO.puts("\n--- Broadcast join (bloom filter) benchmark ---\n")
 
 # Large fact table joined with small dimension — triggers broadcast with bloom pre-filter
-fact_table = Dux.from_query("SELECT x AS id, x % 1000 AS dim_key, x * 1.5 AS amount FROM range(100000) t(x)")
+fact_table =
+  Dux.from_query("SELECT x AS id, x % 1000 AS dim_key, x * 1.5 AS amount FROM range(100000) t(x)")
+
 dim_table = Dux.from_list(for i <- 1..20, do: %{dim_key: i, label: "label_#{i}"})
 
 Benchee.run(

--- a/bench/pool_bench.exs
+++ b/bench/pool_bench.exs
@@ -1,0 +1,67 @@
+# Connection pool throughput benchmark
+# Run with: mix run bench/pool_bench.exs
+#
+# Compares sequential vs concurrent query throughput at different pool sizes.
+# Starts its own Dux.Connection (bypasses the app-level one) to control pool_size.
+
+# Stop the app-level connection so we can start our own with different pool sizes
+case Process.whereis(Dux.Connection) do
+  nil -> :ok
+  pid -> Supervisor.terminate_child(Dux.Supervisor, Dux.Connection)
+end
+
+IO.puts("Setting up benchmark data...\n")
+
+# --- Test each pool size ---
+
+for pool_size <- [1, 2, 4] do
+  # Start connection with this pool size
+  {:ok, pid} = Dux.Connection.start_link(pool_size: pool_size)
+
+  # Pre-compute a 100K dataset
+  medium_sql = "SELECT x AS id, x % 100 AS grp, x * 1.5 AS value FROM range(100000) t(x)"
+  computed = Dux.from_query(medium_sql) |> Dux.compute()
+
+  IO.puts("--- pool_size: #{pool_size} ---\n")
+
+  Benchee.run(
+    %{
+      "sequential: 20 filter+compute" => fn ->
+        for _ <- 1..20 do
+          computed |> Dux.filter_with("value > 75000") |> Dux.compute()
+        end
+      end,
+      "concurrent: 20 filter+compute" => fn ->
+        1..20
+        |> Enum.map(fn _ ->
+          Task.async(fn ->
+            computed |> Dux.filter_with("value > 75000") |> Dux.compute()
+          end)
+        end)
+        |> Task.await_many(30_000)
+      end,
+      "concurrent: 20 full pipelines" => fn ->
+        1..20
+        |> Enum.map(fn _ ->
+          Task.async(fn ->
+            computed
+            |> Dux.filter_with("value > 50000")
+            |> Dux.mutate_with(adjusted: "value * 1.1")
+            |> Dux.group_by(:grp)
+            |> Dux.summarise_with(total: "SUM(adjusted)", n: "COUNT(*)")
+            |> Dux.to_rows()
+          end)
+        end)
+        |> Task.await_many(30_000)
+      end
+    },
+    warmup: 2,
+    time: 5,
+    print: [configuration: false]
+  )
+
+  GenServer.stop(pid)
+  IO.puts("")
+end
+
+IO.puts("Pool benchmark complete.")

--- a/lib/dux.ex
+++ b/lib/dux.ex
@@ -85,7 +85,17 @@ defmodule Dux do
 
   import Dux.SQL.Helpers, only: [qi: 1]
 
-  defstruct [:source, :remote, :workers, :meta, ops: [], names: [], dtypes: %{}, groups: []]
+  defstruct [
+    :source,
+    :remote,
+    :workers,
+    :meta,
+    :conn,
+    ops: [],
+    names: [],
+    dtypes: %{},
+    groups: []
+  ]
 
   @type source ::
           {:parquet, String.t()}
@@ -150,7 +160,7 @@ defmodule Dux do
 
       names = Dux.Backend.table_names(conn, table_ref)
       dtypes = Dux.Backend.table_dtypes(conn, table_ref) |> Map.new()
-      %Dux{source: {:table, table_ref}, names: names, dtypes: dtypes}
+      %Dux{source: {:table, table_ref}, names: names, dtypes: dtypes, conn: conn}
     else
       %Dux{source: {:list, rows}}
     end
@@ -468,7 +478,7 @@ defmodule Dux do
     meta = %{table: table, create: create?}
 
     :telemetry.span([:dux, :io, :write], meta, fn ->
-      conn = Dux.Connection.get_conn()
+      conn = dux.conn || Dux.Connection.get_conn()
       Process.put(:dux_write_ref, extract_source_ref(dux))
       {query_sql, source_setup} = Dux.QueryBuilder.build(dux, conn)
 
@@ -1426,7 +1436,10 @@ defmodule Dux do
     meta = %{n_ops: length(dux.ops), distributed: false}
 
     :telemetry.span([:dux, :query], meta, fn ->
-      conn = Dux.Connection.get_conn()
+      # Use pinned connection if available (from a prior compute on this pipeline),
+      # otherwise get a connection from the pool. This ensures temp tables created
+      # by compute are visible to downstream operations on the same %Dux{}.
+      conn = dux.conn || Dux.Connection.get_conn()
 
       source_ref = extract_source_ref(dux)
       Process.put(:dux_compute_ref, source_ref)
@@ -1440,7 +1453,7 @@ defmodule Dux do
       table_ref = Dux.Backend.query(conn, sql)
       names = Dux.Backend.table_names(conn, table_ref)
       dtypes = Dux.Backend.table_dtypes(conn, table_ref) |> Map.new()
-      result = %Dux{source: {:table, table_ref}, names: names, dtypes: dtypes}
+      result = %Dux{source: {:table, table_ref}, names: names, dtypes: dtypes, conn: conn}
 
       Process.delete(:dux_compute_ref)
       Dux.QueryBuilder.clear_ipc_refs()
@@ -1494,7 +1507,7 @@ defmodule Dux do
   def to_rows(%Dux{} = dux, opts \\ []) do
     computed = compute(dux)
     {:table, table_ref} = computed.source
-    conn = Dux.Connection.get_conn()
+    conn = computed.conn || Dux.Connection.get_conn()
     rows = Dux.Backend.table_to_rows(conn, table_ref)
 
     if Keyword.get(opts, :atom_keys, false) do
@@ -1527,7 +1540,7 @@ defmodule Dux do
   def to_columns(%Dux{} = dux, opts \\ []) do
     computed = compute(dux)
     {:table, table_ref} = computed.source
-    conn = Dux.Connection.get_conn()
+    conn = computed.conn || Dux.Connection.get_conn()
     columns = Dux.Backend.table_to_columns(conn, table_ref)
 
     if Keyword.get(opts, :atom_keys, false) do
@@ -1557,7 +1570,7 @@ defmodule Dux do
       true
   """
   def sql_preview(%Dux{} = dux, opts \\ []) do
-    conn = Dux.Connection.get_conn()
+    conn = dux.conn || Dux.Connection.get_conn()
     {sql, _setup} = Dux.QueryBuilder.build(dux, conn)
 
     if Keyword.get(opts, :pretty, false) do
@@ -1578,7 +1591,7 @@ defmodule Dux do
   def n_rows(%Dux{} = dux) do
     computed = compute(dux)
     {:table, ref} = computed.source
-    conn = Dux.Connection.get_conn()
+    conn = computed.conn || Dux.Connection.get_conn()
     Dux.Backend.table_n_rows(conn, ref)
   end
 
@@ -1608,7 +1621,7 @@ defmodule Dux do
       col_name = to_col_name(column)
       computed = compute(dux)
       {:table, ref} = computed.source
-      conn = Dux.Connection.get_conn()
+      conn = computed.conn || Dux.Connection.get_conn()
       raw_columns = Dux.Backend.table_to_raw_columns(conn, ref)
 
       case Map.fetch(raw_columns, col_name) do
@@ -1737,8 +1750,9 @@ defmodule Dux do
     computed = dux |> head(limit) |> compute()
     {:table, ref} = computed.source
 
-    names = Dux.Backend.table_names(Dux.Connection.get_conn(), ref)
-    columns = Dux.Backend.table_to_columns(Dux.Connection.get_conn(), ref)
+    conn = computed.conn || Dux.Connection.get_conn()
+    names = Dux.Backend.table_names(conn, ref)
+    columns = Dux.Backend.table_to_columns(conn, ref)
     total_rows = n_rows(dux)
 
     # Calculate column widths
@@ -1929,7 +1943,7 @@ defmodule Dux do
     meta = %{format: fmt_atom, path: path}
 
     :telemetry.span([:dux, :io, :write], meta, fn ->
-      conn = Dux.Connection.get_conn()
+      conn = dux.conn || Dux.Connection.get_conn()
       Process.put(:dux_write_ref, extract_source_ref(dux))
       {query_sql, source_setup} = Dux.QueryBuilder.build(dux, conn)
 

--- a/lib/dux/connection.ex
+++ b/lib/dux/connection.ex
@@ -1,11 +1,20 @@
 defmodule Dux.Connection do
   @moduledoc false
 
-  # Manages the ADBC DuckDB connection for this node.
-  # ADBC's Connection is already a GenServer that serializes access,
-  # so this module just holds the pid and provides a lookup API.
+  # Manages the ADBC DuckDB connection(s) for this node.
+  #
+  # Connection PIDs are stored in :persistent_term for zero-cost access
+  # on the query hot path. The GenServer manages lifecycle only (start,
+  # stop, extension loading).
+  #
+  # With pool_size > 1, multiple Adbc.Connection processes share one
+  # Adbc.Database. Queries are dispatched round-robin via :atomics.
 
   use GenServer
+
+  @pt_key :dux_conn
+  @pt_pool_key :dux_conn_pool
+  @pt_counter_key :dux_conn_counter
 
   def start_link(opts \\ []) do
     name = Keyword.get(opts, :name, __MODULE__)
@@ -13,7 +22,24 @@ defmodule Dux.Connection do
   end
 
   @doc false
-  def get_conn(server \\ __MODULE__) do
+  def get_conn(server \\ __MODULE__)
+
+  def get_conn(__MODULE__) do
+    case :persistent_term.get(@pt_pool_key, nil) do
+      nil ->
+        # Single connection mode
+        :persistent_term.get(@pt_key)
+
+      pool ->
+        # Pool mode — round-robin dispatch
+        counter = :persistent_term.get(@pt_counter_key)
+        idx = :atomics.add_get(counter, 1, 1)
+        elem(pool, rem(idx, tuple_size(pool)))
+    end
+  end
+
+  def get_conn(server) do
+    # Named server — fall back to GenServer call
     GenServer.call(server, :get_conn)
   end
 
@@ -29,6 +55,14 @@ defmodule Dux.Connection do
     :ok
   end
 
+  @doc false
+  def pool_size do
+    case :persistent_term.get(@pt_pool_key, nil) do
+      nil -> 1
+      pool -> tuple_size(pool)
+    end
+  end
+
   # --- Callbacks ---
 
   @impl true
@@ -42,26 +76,65 @@ defmodule Dux.Connection do
         path -> [path: path]
       end
 
+    pool_size = Keyword.get(opts, :pool_size, 1)
+
     {:ok, db} = Adbc.Database.start_link([driver: :duckdb] ++ db_opts)
-    {:ok, conn} = Adbc.Connection.start_link(database: db)
 
-    # Disable insertion order preservation for temp table materialization.
-    # This lets DuckDB parallelize CREATE TABLE AS across threads without
-    # coordinating row order — ~5x faster for large result sets.
-    # Users who need ordered output use Dux.sort_by/2 explicitly.
-    Adbc.Connection.query!(conn, "SET preserve_insertion_order = false")
+    conns =
+      for _ <- 1..pool_size do
+        {:ok, conn} = Adbc.Connection.start_link(database: db)
 
-    {:ok, %{db: db, conn: conn}}
+        # Disable insertion order preservation for temp table materialization.
+        # This lets DuckDB parallelize CREATE TABLE AS across threads without
+        # coordinating row order — ~5x faster for large result sets.
+        # Users who need ordered output use Dux.sort_by/2 explicitly.
+        Adbc.Connection.query!(conn, "SET preserve_insertion_order = false")
+
+        conn
+      end
+
+    name = Keyword.get(opts, :name, __MODULE__)
+
+    # Only store in persistent_term for the default (unnamed) instance.
+    # Named instances (tests, multiple databases) use GenServer.call.
+    if name == __MODULE__ do
+      if pool_size == 1 do
+        :persistent_term.put(@pt_key, hd(conns))
+      else
+        :persistent_term.put(@pt_pool_key, List.to_tuple(conns))
+        :persistent_term.put(@pt_counter_key, :atomics.new(1, []))
+        # Also store first conn for single-conn API callers
+        :persistent_term.put(@pt_key, hd(conns))
+      end
+    end
+
+    {:ok, %{db: db, conns: conns, pool_size: pool_size, name: name}}
   end
 
   @impl true
-  def handle_call(:get_conn, _from, %{conn: conn} = state) do
+  def terminate(_reason, %{name: name}) do
+    if name == __MODULE__ do
+      :persistent_term.erase(@pt_key)
+      :persistent_term.erase(@pt_pool_key)
+      :persistent_term.erase(@pt_counter_key)
+    end
+
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
+
+  # Legacy compatibility — keep GenServer call interface working
+  # for any code that bypasses get_conn/0
+  @impl true
+  def handle_call(:get_conn, _from, %{conns: [conn | _]} = state) do
     {:reply, conn, state}
   end
 
-  # Legacy compatibility
   @impl true
-  def handle_call(:get_db, _from, %{conn: conn} = state) do
+  def handle_call(:get_db, _from, %{conns: [conn | _]} = state) do
     {:reply, conn, state}
   end
 end

--- a/test/dux/connection_test.exs
+++ b/test/dux/connection_test.exs
@@ -122,4 +122,59 @@ defmodule Dux.ConnectionTest do
       assert Dux.Backend.table_n_rows(conn, result) == 100
     end
   end
+
+  # ---------- Connection pool ----------
+
+  describe "pool mode" do
+    test "pool_size returns configured size" do
+      # The app-level connection is pool_size: 1 by default
+      assert Dux.Connection.pool_size() >= 1
+    end
+
+    test "get_conn returns a PID" do
+      conn = Dux.Connection.get_conn()
+      assert is_pid(conn)
+    end
+
+    test "compute pins connection to %Dux{}" do
+      require Dux
+      df = Dux.from_query("SELECT 1 AS x") |> Dux.compute()
+      assert df.conn != nil
+      assert is_pid(df.conn)
+    end
+
+    test "chained operations reuse pinned connection" do
+      require Dux
+      df = Dux.from_query("SELECT x FROM range(100) t(x)") |> Dux.compute()
+      # Downstream compute reuses the same connection
+      filtered = df |> Dux.filter_with("x > 50") |> Dux.compute()
+      assert filtered.conn == df.conn
+    end
+
+    test "from_list pins connection for large lists" do
+      data = for i <- 1..1000, do: %{id: i, val: i * 2}
+      df = Dux.from_list(data)
+      assert df.conn != nil
+      # Can chain from it
+      rows = df |> Dux.filter_with("val > 1000") |> Dux.to_rows()
+      assert length(rows) == 500
+    end
+
+    test "concurrent pipelines all succeed" do
+      require Dux
+
+      tasks =
+        for _ <- 1..20 do
+          Task.async(fn ->
+            Dux.from_query("SELECT x FROM range(100) t(x)")
+            |> Dux.filter_with("x > 50")
+            |> Dux.to_rows()
+            |> length()
+          end)
+        end
+
+      results = Task.await_many(tasks, 10_000)
+      assert Enum.all?(results, &(&1 == 49))
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- **Zero-cost connection access**: Replace `GenServer.call` in `get_conn/0` with `:persistent_term` read. The connection PID is set once at startup — no reason for a GenServer round-trip on every query.
- **Connection pool**: `pool_size: N` starts N `Adbc.Connection` processes against one `Adbc.Database`. Round-robin dispatch via `:atomics` (lock-free). Default `pool_size: 1` is fully backwards compatible.
- **Connection pinning**: `%Dux{}` structs carry a `:conn` field. `compute/1` pins the connection used, so downstream ops (`to_rows`, `filter`, etc.) reuse the same connection. Prevents temp table visibility issues across pooled connections.
- **Pool benchmark**: `bench/pool_bench.exs` compares sequential vs concurrent throughput at pool_size 1, 2, and 4.

Closes #39 

## How to use

```elixir
# Default — single connection (backwards compatible, no changes needed)
Dux.Connection.start_link()

# Pool mode for web apps handling concurrent requests
Dux.Connection.start_link(pool_size: 4)

# All Dux API calls work identically — pool dispatch is internal
df = Dux.from_parquet("data.parquet") |> Dux.filter(x > 100) |> Dux.compute()
```

## Design decisions

- **persistent_term for hot path**: `get_conn/0` is called ~50 times across the codebase on every query path. Moving from GenServer.call to persistent_term eliminates one serialization layer.
- **Named servers use GenServer.call**: `get_conn(:my_name)` still uses GenServer.call. Only the default instance uses persistent_term. This keeps test isolation working.
- **Round-robin dispatch**: Simplest strategy, lock-free via `:atomics`. The ADBC GenServer already serializes per-connection, so interleaving is just mailbox queueing.
- **Connection pinning via struct field**: Adding `:conn` to `%Dux{}` is minimal and composable. `compute/1` sets it, downstream ops check `dux.conn || get_conn()`.
- **Distributed path unaffected**: Workers have their own connections. The pool only applies to local operations.

## Pool benchmark results (`bench/pool_bench.exs`)

20 concurrent filter+compute on 100K rows:

| pool_size | Sequential | Concurrent | Speedup |
|-----------|-----------|------------|---------|
| 1 | 26.6ms | 25.7ms | 1.0x |
| 2 | 32.8ms | 24.4ms | 1.3x |
| 4 | 26.0ms | 26.5ms | ~1.0x |

For fast queries (~1ms each), the pool doesn't dramatically change throughput since DuckDB's internal thread pool already parallelizes. The pool's value is for web apps where concurrent requests queue up on a single ADBC GenServer, especially with heavier queries (joins, large scans, file IO) where individual query latency is higher and GenServer mailbox contention becomes the bottleneck.

## Test plan

- [x] All 655 tests pass (649 existing + 6 new pool tests)
- [x] `mix check` — format, compile, test, credo all pass
- [x] Pool mode: round-robin dispatch verified (4 unique PIDs from 8 calls)
- [x] Connection pinning: chained ops reuse same connection
- [x] from_list pinning: large lists pin to ingestion connection
- [x] Concurrent pipelines: 20 Tasks all succeed
- [x] No regression in single-connection benchmarks
- [x] Pool throughput benchmark added (`bench/pool_bench.exs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)