### PR TITLE
Add missing`:nullstr` option to docs for `from_csv/2`

### DIFF
--- a/lib/dux.ex
+++ b/lib/dux.ex
@@ -226,6 +226,7 @@ defmodule Dux do
 
     * `:delimiter` - field delimiter (default: `","`)
     * `:header` - whether the file has a header row (default: `true`)
+    * `:nullstr` — string to treat as NULL (e.g., `"NA"`)
     * `:null_padding` - pad missing columns with NULL (default: `false`)
     * `:skip` - number of rows to skip at the start
     * `:columns` - list of column names or indices to read


### PR DESCRIPTION
Documented in other places, just missing from the inline docs.