### PR TITLE
[codex] fix temporal values from from_list

### DIFF
--- a/lib/dux/query_builder.ex
+++ b/lib/dux/query_builder.ex
@@ -459,6 +459,10 @@ defmodule Dux.QueryBuilder do
   defp encode_value(v) when is_float(v), do: Float.to_string(v)
   defp encode_value(true), do: "true"
   defp encode_value(false), do: "false"
+  defp encode_value(%Date{} = v), do: "DATE '#{Date.to_iso8601(v)}'"
+  defp encode_value(%Time{} = v), do: "TIME '#{Time.to_iso8601(v)}'"
+  defp encode_value(%NaiveDateTime{} = v), do: "TIMESTAMP '#{NaiveDateTime.to_iso8601(v)}'"
+  defp encode_value(%DateTime{} = v), do: "TIMESTAMPTZ '#{DateTime.to_iso8601(v)}'"
 
   defp encode_value(v) when is_binary(v) do
     "'#{escape_sql_string(v)}'"

--- a/test/dux/verb_test.exs
+++ b/test/dux/verb_test.exs
@@ -422,6 +422,23 @@ defmodule Dux.VerbTest do
 
       assert result == 10
     end
+
+    test "handles temporal values in small lists" do
+      result =
+        Dux.from_list([
+          %{
+            "date" => ~D[2001-01-01],
+            "time" => ~T[12:34:56],
+            "datetime" => ~N[2001-01-01 00:00:00]
+          }
+        ])
+        |> Dux.to_rows()
+
+      assert [row] = result
+      assert row["date"] == ~D[2001-01-01]
+      assert Time.compare(row["time"], ~T[12:34:56]) == :eq
+      assert NaiveDateTime.compare(row["datetime"], ~N[2001-01-01 00:00:00]) == :eq
+    end
   end
 
   describe "compute/1" do


### PR DESCRIPTION
## Summary

- Encode Elixir `Date`, `Time`, `NaiveDateTime`, and `DateTime` structs as typed DuckDB literals in the small-list `from_list/1` SQL path.
- Add a regression test covering temporal values in small lists.

## Root Cause

Small list sources are represented as inline `SELECT ... UNION ALL ...` SQL, but `Dux.QueryBuilder.encode_value/1` only handled nil, numbers, booleans, and strings. Temporal structs therefore raised a `FunctionClauseError` before DuckDB could evaluate the query. Large lists already used ADBC ingestion and did not hit this encoder.

## Validation

- `mix test test/dux/verb_test.exs`
- Manual reproduction with `Dux.peek/1` on the example from the issue

Fixes #51