### PR TITLE
Testing fixes

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -34,11 +34,12 @@ container_exclusion =
 
 Process.flag(:trap_exit, old)
 
+Dux.exec("SET memory_limit = '8GB';")
 
-  case List.flatten([distributed_exclusion, container_exclusion]) do
-    [] ->
-      ExUnit.start()
+case List.flatten([distributed_exclusion, container_exclusion]) do
+  [] ->
+    ExUnit.start()
 
-    exclusions ->
-      ExUnit.start(exclude: exclusions)
-  end
+  exclusions ->
+    ExUnit.start(exclude: exclusions)
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,25 +1,44 @@
 # Start distribution for :peer-based distributed tests.
 # :peer needs the parent node to be alive for dist-connected peers.
-unless Node.alive?() do
-  sname = :"dux_test_#{:erlang.unique_integer([:positive])}"
+distributed_exclusion =
+  if Node.alive?() do
+    []
+  else
+    sname = :"dux_test_#{:erlang.unique_integer([:positive])}"
 
-  case Node.start(sname, :shortnames) do
-    {:ok, _} ->
-      :ok
+    case Node.start(sname, :shortnames) do
+      {:ok, _} ->
+        []
 
-    {:error, reason} ->
-      IO.puts("⚠ Distribution not available (#{inspect(reason)}) — excluding :distributed tests")
+      {:error, reason} ->
+        IO.puts(
+          "⚠ Distribution not available (#{inspect(reason)}) — excluding :distributed tests"
+        )
+
+        :distributed
+    end
   end
-end
 
 # Start testcontainers for integration tests (requires Docker)
-case Testcontainers.start_link() do
-  {:ok, _} -> :ok
-  {:error, _} -> IO.puts("⚠ Docker not available — excluding :container tests")
-end
+old = Process.flag(:trap_exit, true)
 
-if Node.alive?() do
-  ExUnit.start()
-else
-  ExUnit.start(exclude: [:distributed])
-end
+container_exclusion =
+  case Testcontainers.start_link() do
+    {:ok, _} ->
+      []
+
+    {:error, reason} ->
+      IO.puts("⚠ Test container not available (#{inspect(reason)}) — excluding :container tests")
+      :container
+  end
+
+Process.flag(:trap_exit, old)
+
+
+  case List.flatten([distributed_exclusion, container_exclusion]) do
+    [] ->
+      ExUnit.start()
+
+    exclusions ->
+      ExUnit.start(exclude: exclusions)
+  end


### PR DESCRIPTION
If Docker is not installed, the Testcontainer process crashes and takes the calling process with it, so the test suite never runs. This could be handled in different ways, but the simplest seems to be to trap that exit.

Running the tests locally (with the distributed and container tests excluded), several tests failed for me due to DuckDB out-of-memory errors. With some trial-and-error testing it appears to me that 8 GB is the minimum that will work.